### PR TITLE
Whitelist etherchain.org, ethpool.org, ethermine.org & ethernodes.org

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -28,6 +28,10 @@
   "myetherwallet.groovehq.com",
   "shapeshift.io",
   "webtask.io",
+  "ethpool.org",
+  "ethermine.org",
+  "etherchain.org",
+  "ethernodes.org",
   "www.bity.com",
   "www.changelly.com",
   "www.coinbase.com",
@@ -56,5 +60,9 @@
   "www.myetherwallet.com",
   "www.myetherwallet.groovehq.com",
   "www.shapeshift.io",
-  "www.webtask.io"
+  "www.webtask.io",
+  "www.ethpool.org",
+  "www.ethermine.org",
+  "www.etherchain.org",
+  "www.ethernodes.org
 ]


### PR DESCRIPTION
Currently ethermine.org is getting erroneously blocked. In order to avoid our sites from getting blocked in the future please add them to your whitelist.