### PR TITLE
Added steem.supply to white ilst

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -72,5 +72,6 @@
 "www.etherecho.com",
 "etherecho.com",
 "www.ethercard.io",
-"ethercard.io"
+"ethercard.io",
+  "steem.supply"
 ]


### PR DESCRIPTION
Somebody reported that MetaMask is blacklisting this site. I'm the owner and I can testify there's no phishing or malware: no registration needed, no redirecting to other urls.