### PR TITLE
Adding etherplan.com www.etherplan.com to the whitelist.

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -1,4 +1,6 @@
 [
+"etherplan.com",
+"www.etherplan.com",
 "www.etheralert.io",
 "etheralert.io",
 "www.bity.com",


### PR DESCRIPTION
Etherplan is a global wealth management network on Ethereum.