### PR TITLE
Add erroneously blocked domain (ethex.market)

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -1,4 +1,5 @@
 [
+"ethex.market",
 "etherplan.com",
 "www.etherplan.com",
 "www.etheralert.io",


### PR DESCRIPTION
Ethex.market is a new distributed exchange DApp. Currently only fully deployed on Ropsten. Works as a registered parity dapp (in applications tab), or with Parity Chrome extension at ethex.market or with metamask Chrome extension at ethex.market. Metamask is very slow on ropsten. Should work in Mist, but we haven't tested it at all.