### PR TITLE
Add kybernetwork.io to blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,5 +1,6 @@
 [
 "kybernet.network",
+"kybernetwork.io",
 "tokensale.kybernet.network",  
 "myetherwalletconfirm.com",  
 "kvnuke.github.io",  


### PR DESCRIPTION
Impersonates kyber.network

As reported on MetaMask support center.