### PR TITLE
blacklist request-network.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -2113,4 +2113,5 @@
 "www.myetherwallet.no",
 "myetherwallet.nokia",
 "www.myetherwallet.nokia",
-"myetherwallet.northw
+"myetherwallet.north",
+"request-network.com"


### PR DESCRIPTION
Fix typo about myetherwallet.north, 

blacklist request-network.com (ongoing phishing on our slack)
The REAL website is https://request.network  (see our blog : https://blog.request.network/)