### PR TITLE
Add etherdelta.io to blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -252,6 +252,7 @@
 "xn--myethewallt-crb.com",
 "cobinhood.io",
 "etherdelta.su",
+"etherdelta.io",
 "myetherwallett.neocities.org",
 "myetherwallet-secure.com",
 "myethereumwalletntw.info",


### PR DESCRIPTION
Etherdelta.io is apparently a white-hat action, however that hat color is not forever guaranteed.