### PR TITLE
paypex.org

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -2601,5 +2601,6 @@
 "wallets-blockchain.com", 
 "spectre-ai.org",
 "spectre-ai.net",
-"spectre.site"
+"spectre.site",
+"paypex.org"
 ]


### PR DESCRIPTION
Extremly fishy ICO found, not smart contract and random address generator, only 2 address with all the tokens and sending them in batches to ED.