### PR TITLE
Remove etherdelta.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -38,7 +38,6 @@
 "bitslier.com",
 "etherdella.com",
 "singularty.net",
-"etherdelta.com",
 "iconfoundation.io",
 "kittystat.com",
 "singularitynet.in",


### PR DESCRIPTION
The proper owners have regained control of the domain name. The site is back up, and secured again.

https://www.reddit.com/r/EtherDelta/comments/7lf9ni/psa_site_has_been_restored_and_secured_official/