### PR TITLE
etherdelta.pw

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"etherdelta.pw",
 "ethereum-giveaway.org",
 "mysimpletoken.org",
 "binancc.com",


### PR DESCRIPTION
Fake EtherDelta domain - hosted on the same server as the fake powrledger.io/airdrop/ domain. Assuming bad actor.

https://urlscan.io/result/83fd9bac-ed49-411e-b534-b4ecb6681c64#summary