### PR TITLE
Custom RPC nodes

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -121,8 +121,9 @@
     overflow-y: hidden;
 }
 
-.ext-etheraddresslookup-address_stats_hover .ext-etheraddresslookup-address_stats_hover_content > p {
-    margin: 5%;
+.ext-etheraddresslookup-address_stats_hover .ext-etheraddresslookup-address_stats_hover_content > span {
+    padding: 10%;
+    margin-top: 5%;
     font-size: 10pt;
     text-decoration: none;
     font-style: normal;

--- a/css/app.css
+++ b/css/app.css
@@ -144,3 +144,26 @@
 .ext-etheraddresslookup-0xaddress:hover .ext-etheraddresslookup-address_stats_hover .ext-etheraddresslookup-address_stats_hover_content {
     display: inline-block;
 }
+
+.ext-etheraddresslookup-address_stats_hover_node_error {
+    all: initial;
+    background: #d02626;
+    border-radius: 50%;
+    height: 10px;
+    width: 10px;
+    position: absolute;
+    right: 5%;
+    display: none;
+    z-index: 2;
+}
+.ext-etheraddresslookup-address_stats_hover_node_ok {
+    all: initial;
+    background: #32a735;
+    border-radius: 50%;
+    height: 10px;
+    width: 10px;
+    position: absolute;
+    right: 5%;
+    display: none;
+    z-index: 1;
+}

--- a/css/app.css
+++ b/css/app.css
@@ -104,6 +104,7 @@
 }
 
 .ext-etheraddresslookup-address_stats_hover .ext-etheraddresslookup-address_stats_hover_content {
+    all: initial;
     display: none;
     position: absolute;
     bottom: 5%;
@@ -122,12 +123,13 @@
 }
 
 .ext-etheraddresslookup-address_stats_hover .ext-etheraddresslookup-address_stats_hover_content > span {
-    padding: 10%;
-    margin-top: 5%;
+    all: initial;
     font-size: 10pt;
     text-decoration: none;
     font-style: normal;
     font-family: 'Verdana';
+    display: block;
+    line-height: 2em;
 }
 .ext-etheraddresslookup-address_stats_hover .ext-etheraddresslookup-address_stats_hover_content > a > img {
     display: inline;

--- a/js/DomManipulator.js
+++ b/js/DomManipulator.js
@@ -364,8 +364,8 @@ class EtherAddressLookup {
         var objHoverNodeContent = document.createElement("div");
         objHoverNodeContent.className = "ext-etheraddresslookup-address_stats_hover_content";
         objHoverNodeContent.innerHTML = "<p id='ext-etheraddresslookup-fetching_data_"+intUniqueId+"'><strong>Fetching Data...</strong></p>";
-        objHoverNodeContent.innerHTML += "<br /><span id='ext-etheraddresslookup-address_balance_"+intUniqueId+"'></span><br />";
-        objHoverNodeContent.innerHTML += "<span id='ext-etheraddresslookup-transactions_out_"+intUniqueId+"'></span><br />";
+        objHoverNodeContent.innerHTML += "<span id='ext-etheraddresslookup-address_balance_"+intUniqueId+"'></span>";
+        objHoverNodeContent.innerHTML += "<span id='ext-etheraddresslookup-transactions_out_"+intUniqueId+"'></span>";
         objHoverNodeContent.innerHTML += "<span id='ext-etheraddresslookup-contract_address_"+intUniqueId+"'></span>";
 
         objHoverNode.appendChild(objHoverNodeContent);

--- a/js/DomManipulator.js
+++ b/js/DomManipulator.js
@@ -13,6 +13,7 @@ class EtherAddressLookup {
     setDefaultExtensionSettings()
     {
         this.blHighlight = false;
+        this.blPerformAddressLookups = true;
         this.strBlockchainExplorer = "https://etherscan.io/address";
         this.strRpcProvider = "https://localhost:8545";
 
@@ -38,6 +39,12 @@ class EtherAddressLookup {
         //Get the blockchain explorer for the user
         objBrowser.runtime.sendMessage({func: "blockchain_explorer"}, function(objResponse) {
             this.strBlockchainExplorer = objResponse.resp;
+            ++this.intSettingsCount;
+        }.bind(this));
+
+        //Get the perform address lookup option
+        objBrowser.runtime.sendMessage({func: "perform_address_lookups"}, function(objResponse) {
+            this.blPerformAddressLookups = objResponse.resp;
             ++this.intSettingsCount;
         }.bind(this));
 
@@ -142,7 +149,9 @@ class EtherAddressLookup {
             }
             this.convertAddressToLink();
 
-            this.setAddressOnHoverBehaviour();
+            if(this.blPerformAddressLookups > 0) {
+                this.setAddressOnHoverBehaviour();
+            }
         }
     }
 

--- a/js/DomManipulator.js
+++ b/js/DomManipulator.js
@@ -364,6 +364,8 @@ class EtherAddressLookup {
         var objHoverNodeContent = document.createElement("div");
         objHoverNodeContent.className = "ext-etheraddresslookup-address_stats_hover_content";
         objHoverNodeContent.innerHTML = "<p id='ext-etheraddresslookup-fetching_data_"+intUniqueId+"'><strong>Fetching Data...</strong></p>";
+        objHoverNodeContent.innerHTML += "<div id='ext-etheraddresslookup-address_stats_hover_node_error_"+intUniqueId+"' class='ext-etheraddresslookup-address_stats_hover_node_error'></div>";
+        objHoverNodeContent.innerHTML += "<div id='ext-etheraddresslookup-address_stats_hover_node_ok_"+intUniqueId+"' class='ext-etheraddresslookup-address_stats_hover_node_ok'></div>";
         objHoverNodeContent.innerHTML += "<span id='ext-etheraddresslookup-address_balance_"+intUniqueId+"'></span>";
         objHoverNodeContent.innerHTML += "<span id='ext-etheraddresslookup-transactions_out_"+intUniqueId+"'></span>";
         objHoverNodeContent.innerHTML += "<span id='ext-etheraddresslookup-contract_address_"+intUniqueId+"'></span>";
@@ -386,7 +388,9 @@ class EtherAddressLookup {
                 var intTransactionCount = "";
                 if(error) {
                     intTransactionCount = -1;
+                    objHoverNodeContent.querySelector("#ext-etheraddresslookup-address_stats_hover_node_error_"+intUniqueId).style.display = "inline";
                 } else {
+                    objHoverNodeContent.querySelector("#ext-etheraddresslookup-address_stats_hover_node_ok_"+intUniqueId).style.display = "inline";
                     intTransactionCount = parseInt(result).toLocaleString();
                 }
 
@@ -403,7 +407,9 @@ class EtherAddressLookup {
                 var flEthBalance = "";
                 if(error) {
                     flEthBalance = -1;
+                    objHoverNodeContent.querySelector("#ext-etheraddresslookup-address_stats_hover_node_error_"+intUniqueId).style.display = "inline";
                 } else {
+                    objHoverNodeContent.querySelector("#ext-etheraddresslookup-address_stats_hover_node_ok_"+intUniqueId).style.display = "inline";
                     flEthBalance = web3.fromWei(result.toString(10), "ether").toLocaleString("en-US", {maximumSignificantDigits: 9});
                 }
 
@@ -421,7 +427,9 @@ class EtherAddressLookup {
 
                 if(error) {
                     objContractAddress.innerHTML += "<small>Unable to determine if contract</small>";
+                    objHoverNodeContent.querySelector("#ext-etheraddresslookup-address_stats_hover_node_error_"+intUniqueId).style.display = "inline";
                 } else {
+                    objHoverNodeContent.querySelector("#ext-etheraddresslookup-address_stats_hover_node_ok_"+intUniqueId).style.display = "inline";
                     var blIsContractAddress = result == "0x" ? false : true;
                     if (blIsContractAddress) {
                         objContractAddress.innerHTML += "<small>This is a contract address</small>";

--- a/js/app/rpcNodeSelector.js
+++ b/js/app/rpcNodeSelector.js
@@ -1,0 +1,104 @@
+let objBrowser = chrome ? chrome : browser;
+
+class RpcNodeSelector
+{
+
+    constructor()
+    {
+        //No need to do anything here.
+    }
+
+    /**
+     * Populates the RPC node input box with the current RPC node endpoint.
+     */
+    populateRpcNodeInput()
+    {
+        objBrowser.runtime.sendMessage({func: "rpc_provider"}, function(objResponse) {
+            document.getElementById("ext-etheraddresslookup-rpcnode_modify_url").value = objResponse.resp;
+        });
+    }
+
+    resetFormValues(objEvent)
+    {
+        objBrowser.runtime.sendMessage({func: "rpc_default_provider"}, function(objResponse) {
+            document.getElementById("ext-etheraddresslookup-rpcnode_modify_url").value = objResponse.resp;
+        });
+
+        objEvent.preventDefault();
+    }
+
+    saveFormValues(objEvent)
+    {
+        var objRpcValue = document.getElementById("ext-etheraddresslookup-rpcnode_modify_url");
+
+        document.getElementById("ext-etheraddresslookup-rpcnode_connected_status").classList.add("hide-me");
+        document.getElementById("ext-etheraddresslookup-rpcnode_eth_version").classList.add("hide-me");
+        document.getElementById("ext-etheraddresslookup-rpcnode_api_version").classList.add("hide-me");
+        document.getElementById("ext-etheraddresslookup-rpcnode_network_version").classList.add("hide-me");
+
+        var objRpcSuccessNode = document.getElementById("ext-etheraddresslookup-rpcnode_success");
+        objRpcSuccessNode.classList.add("hide-me");
+
+        if( RpcNodeSelector.rpcEndpointIsAvailable(objRpcValue.value) ) {
+            localStorage.setItem("ext-etheraddresslookup-rpc_node", objRpcValue.value)
+        }
+
+        objEvent.preventDefault();
+
+        RpcNodeSelector.updateNodeDetails();
+
+        return false;
+    }
+
+    static rpcEndpointIsAvailable(strHttpProvider)
+    {
+        var objWeb3 = new Web3(new Web3.providers.HttpProvider(strHttpProvider));
+        var objRpcErrorNode = document.getElementById("ext-etheraddresslookup-rpcnode_errors");
+        objRpcErrorNode.innerText = "";
+        objRpcErrorNode.classList.add("hide-me");
+
+        try {
+            var strVersion = objWeb3.version.ethereum;
+        } catch (objException) {
+            objRpcErrorNode.innerText = objException.message;
+            objRpcErrorNode.classList.remove("hide-me");
+            return false;
+        }
+
+        var objRpcSuccessNode = document.getElementById("ext-etheraddresslookup-rpcnode_success");
+        objRpcSuccessNode.classList.remove("hide-me");
+
+        console.log("RPC Node Version: "+ strVersion);
+        return true;
+    }
+
+    static updateNodeDetails()
+    {
+        var strWeb3Provider = localStorage.getItem("ext-etheraddresslookup-rpc_node");
+        var objWeb3 = new Web3(new Web3.providers.HttpProvider(strWeb3Provider));
+
+        document.getElementById("ext-etheraddresslookup-rpcnode_connected_status").classList.remove("hide-me");
+        document.getElementById("ext-etheraddresslookup-rpcnode_eth_version").classList.remove("hide-me");
+        document.getElementById("ext-etheraddresslookup-rpcnode_api_version").classList.remove("hide-me");
+        document.getElementById("ext-etheraddresslookup-rpcnode_network_version").classList.remove("hide-me");
+
+        var blConnected = objWeb3.isConnected();
+        document.getElementById("ext-etheraddresslookup-rpcnode_connected_status").innerHTML = (blConnected ? "CONNECTED" : "DISCONNECTED") + "<br />";
+        if(blConnected) {
+            document.getElementById("ext-etheraddresslookup-rpcnode_eth_version").innerHTML = "ETH Version: " + objWeb3.version.ethereum +"<br />";
+            document.getElementById("ext-etheraddresslookup-rpcnode_api_version").innerHTML = "API Version: " + objWeb3.version.api +"<br />";
+            document.getElementById("ext-etheraddresslookup-rpcnode_network_version").innerHTML = "API Version: " + objWeb3.version.network +"<br />";
+        }
+    }
+
+}
+
+//On page load do everything.
+(function() {
+    let objRpcNodeSelector = new RpcNodeSelector();
+    objRpcNodeSelector.populateRpcNodeInput();
+
+    var objForm = document.getElementById("ext-etheraddresslookup-rpcnode_modify_form");
+    objForm.addEventListener("reset", objRpcNodeSelector.resetFormValues, true);
+    objForm.addEventListener("submit", objRpcNodeSelector.saveFormValues, true);
+})();

--- a/js/app/toggleAddressLookups.js
+++ b/js/app/toggleAddressLookups.js
@@ -1,0 +1,22 @@
+//On page load it checks/unchecks the checkbox
+(function() {
+    refreshPerformAddressLookups();
+})();
+
+//Sets the local storage to remember their RPC address lookup setting
+function togglePerformAddressLookups()
+{
+    var objAddressLookups = document.getElementById("ext-etheraddresslookup-perform_address_lookups");
+    var intAddressLookups = objAddressLookups.checked ? 1 : 0;
+    localStorage.setItem("ext-etheraddresslookup-perform_address_lookups", intAddressLookups);
+
+    refreshPerformAddressLookups();
+}
+
+function refreshPerformAddressLookups() {
+    var intAddressLookups = localStorage.getItem("ext-etheraddresslookup-perform_address_lookups");
+    if(intAddressLookups === null) {
+        intAddressLookups = 1;
+    }
+    document.getElementById("ext-etheraddresslookup-perform_address_lookups").checked = (intAddressLookups == 1 ? true : false);
+}

--- a/js/options.js
+++ b/js/options.js
@@ -97,7 +97,14 @@ objBrowser.runtime.onMessage.addListener(
                 strResponse = getWhitelistedDomains();
                 break;
             case 'rpc_provider' :
-                    strResponse = "https://freely-central-lark.quiknode.io/9fe4c4a0-2ea2-4ac1-ab64-f92990cd2914/118-xxADc8hKSSB9joCb-g==/";
+                    if(localStorage.getItem("ext-etheraddresslookup-rpc_node") === null) {
+                        strResponse = "https://freely-central-lark.quiknode.io/9fe4c4a0-2ea2-4ac1-ab64-f92990cd2914/118-xxADc8hKSSB9joCb-g==/";
+                    } else {
+                        strResponse = localStorage.getItem("ext-etheraddresslookup-rpc_node");
+                    }
+                break;
+            case 'rpc_default_provider' :
+                strResponse = "https://freely-central-lark.quiknode.io/9fe4c4a0-2ea2-4ac1-ab64-f92990cd2914/118-xxADc8hKSSB9joCb-g==/";
                 break;
             default:
                 strResponse = "unsupported";

--- a/js/options.js
+++ b/js/options.js
@@ -12,6 +12,12 @@ let objBrowser = chrome ? chrome : browser;
         objOptionBlockchainExplorer.addEventListener('change', toggleBlockchainExplorer);
     }
 
+    //Toggle the address lookups option and set it in LocalStorage
+    var objAddressLookups = document.getElementById('ext-etheraddresslookup-perform_address_lookups');
+    if(objAddressLookups) {
+        objAddressLookups.addEventListener('click', togglePerformAddressLookups);
+    }
+
     //Toggle the blacklist domains option and set it in LocalStorage
     var objBlacklistDomains = document.getElementById('ext-etheraddresslookup-blacklist_domains');
     if(objBlacklistDomains) {
@@ -105,6 +111,14 @@ objBrowser.runtime.onMessage.addListener(
                 break;
             case 'rpc_default_provider' :
                 strResponse = "https://freely-central-lark.quiknode.io/9fe4c4a0-2ea2-4ac1-ab64-f92990cd2914/118-xxADc8hKSSB9joCb-g==/";
+                break;
+            case 'perform_address_lookups' :
+                //This option is enabled by default
+                if(localStorage.getItem("ext-etheraddresslookup-perform_address_lookups") === null) {
+                    strResponse = 1;
+                } else {
+                    strResponse = localStorage.getItem("ext-etheraddresslookup-perform_address_lookups");
+                }
                 break;
             default:
                 strResponse = "unsupported";

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "EtherAddressLookup",
   "short_name": "EtherAddressLookup",
   "description": "Adds links to strings that look like Ethereum addresses to your favorite blockchain explorer.",
-  "version": "1.13.2",
+  "version": "1.14",
 
   "browser_action": {
     "default_icon": "images/icon.png",

--- a/options.html
+++ b/options.html
@@ -74,7 +74,8 @@
 
         <hr />
 
-        <a href="http://harrydenley.com/ethaddresslookup-chrome-extension-release/" target="_blank">Read Author Blog</a>
+        <a href="https://harrydenley.com/ethaddresslookup-chrome-extension-release/" target="_blank">Read Author Blog</a> &mdash;
+        <a href="https://twitter.com/EthAddrLookup" target="_blank">@EthAddrLookup</a>
         <br/>
         <strong>Version:</strong> <span id="ext-manifest_version"></span> &mdash; BETA
     </div>

--- a/options.html
+++ b/options.html
@@ -8,7 +8,7 @@
 </head>
 <body id="ext-etheraddresslookup-popup">
 <div id="content">
-    <h3 class="text-center">EtherAddressLookup</h3>
+    <h4 class="text-center">EtherAddressLookup</h4>
 
     <div id="ext-etheraddresslookup-bookmarks" class="ext-etheraddresslookup-center">
         <!--- populated by js/app/toggleBookmarks.js showBookmarks() -->
@@ -24,7 +24,10 @@
         <span>Highlight Matches</span>
     </label>
 
-    <br/>
+    <label class="fancy-checkbox">
+        <input type="checkbox" name="ext-etheraddresslookup-show_style" id="ext-etheraddresslookup-perform_address_lookups">
+        <span>Perform address lookups</span>
+    </label>
 
     <label class="fancy-checkbox">
         <input type="checkbox" name="ext-etheraddresslookup-blacklist_domains" id="ext-etheraddresslookup-blacklist_domains">
@@ -85,6 +88,7 @@
 <script src="js/app/chooseBlockchain.js"></script>
 <script src="js/app/toggleBlacklistDomains.js"></script>
 <script src="js/app/toggleBookmarks.js"></script>
+<script src="/js/app/toggleAddressLookups.js"></script>
 
 <script src="js/options.js"></script>
 </body>

--- a/settings.html
+++ b/settings.html
@@ -86,6 +86,32 @@
     </div>
 
     <div class="pure-g">
+        <div class="pure-u-1-1">
+            <h3>RPC Node</h3>
+            <p>Here you can set the RPC node (ie: <code>localhost:8545</code>) for address lookups. EAL supplies a mainnet
+                one for you that is maintained by Quiknode, but you may want to use your own.</p>
+            <p>Overwriting the default node will be helpful if you want lookups done on a testnet.</p>
+            <div class="warning margin-15 hide-me" id="ext-etheraddresslookup-rpcnode_errors"></div>
+            <div class="success margin-15 hide-me" id="ext-etheraddresslookup-rpcnode_success">
+                RPC Node setting has been updated. <br />
+                <span id="ext-etheraddresslookup-rpcnode_connected_status"></span>
+                <span id="ext-etheraddresslookup-rpcnode_eth_version"></span>
+                <span id="ext-etheraddresslookup-rpcnode_api_version"></span>
+                <span id="ext-etheraddresslookup-rpcnode_network_version"></span>
+            </div>
+            <form method="post" action="" class="pure-form pure-form-aligned" id="ext-etheraddresslookup-rpcnode_modify_form">
+                <div class="pure-control-group">
+                    <label for="ext-etheraddresslookup-rpcnode_modify_url">RPC Node:</label>
+                    <input type="text" name="rpcnode" placeholder="localhost:8545" id="ext-etheraddresslookup-rpcnode_modify_url">
+                </div>
+
+                <button type="reset" class="pure-button pure-button-secondary" id="ext-etheraddresslookup-rpcnode_reset_form">Reset to Default</button>
+                <button type="submit" class="pure-button pure-button-primary">Save</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="pure-g">
         <div class="pure-u-2-3">
             <h3>Special Thanks</h3>
             <p>I'd like to dedicate this block to thank the 3rd party teams for maintaining their blacklists.</p>
@@ -108,8 +134,10 @@
             <p>Thanks, <br />&mdash; Harry.</p>
         </div>
     </div>
+<script src="js/app/lib/web3-light.min.js"></script>
 <script src="js/app/toggleBookmarks.js"></script>
 <script src="js/app/lib/URI.min.js"></script>
 <script src="js/app/historyInspector.js"></script>
+<script src="js/app/rpcNodeSelector.js"></script>
 </body>
 </html>

--- a/settings.html
+++ b/settings.html
@@ -89,7 +89,7 @@
         <div class="pure-u-1-1">
             <h3>RPC Node</h3>
             <p>Here you can set the RPC node (ie: <code>localhost:8545</code>) for address lookups. EAL supplies a mainnet
-                one for you that is maintained by Quiknode, but you may want to use your own.</p>
+                one for you that is maintained by <a href="https://quiknode.io/?ref=EtherAddressLookup" target="_blank">Quiknode</a>, but you may want to use your own.</p>
             <p>Overwriting the default node will be helpful if you want lookups done on a testnet.</p>
             <div class="warning margin-15 hide-me" id="ext-etheraddresslookup-rpcnode_errors"></div>
             <div class="success margin-15 hide-me" id="ext-etheraddresslookup-rpcnode_success">

--- a/settings.html
+++ b/settings.html
@@ -99,6 +99,7 @@
                 <span id="ext-etheraddresslookup-rpcnode_api_version"></span>
                 <span id="ext-etheraddresslookup-rpcnode_network_version"></span>
             </div>
+
             <form method="post" action="" class="pure-form pure-form-aligned" id="ext-etheraddresslookup-rpcnode_modify_form">
                 <div class="pure-control-group">
                     <label for="ext-etheraddresslookup-rpcnode_modify_url">RPC Node:</label>


### PR DESCRIPTION
This feature lets you make EAL use your own RPC node (which is used for the onhover address to get the address stats (https://github.com/409H/EtherAddressLookup/releases/tag/v1.12)). This will allow for the option for stats to be fetched from the various testnets.

![image](https://user-images.githubusercontent.com/2313704/34472188-dd857dc0-ef53-11e7-81ac-b1daae10837f.png)

![image](https://user-images.githubusercontent.com/2313704/34472189-ebf4b95c-ef53-11e7-8011-3f6571738f2a.png)
