### PR TITLE
crowdstart.capital

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -1,4 +1,5 @@
 [
+"crowdstart.capital",
 "materiel.net",
 "beether.net",
 "raw.githubusercontent.com",


### PR DESCRIPTION
Update domains to include http://crowdstart.capital, the website of XSC and Crowdstart Capital, an incentive scheme for the blockchain ecosystem.