### PR TITLE
Adding zenprolocol.com to blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"zenprolocol.com",
 "ethscan.io",
 "etherscan.in",
 "props-project.com",


### PR DESCRIPTION
1. Website not available, https://urlscan.io/result/6bbbc757-947f-4c6d-bff9-234b7a935f56#summary
2. https://www.whois.com/whois/zenprolocol.com