### PR TITLE
Added chronologic.network to the whitelist

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -129,5 +129,6 @@
 "canya.io",
 "www.canya.io",
 "dashboard.canya.io",
+"chronologic.network",
 "www.maecenas.co"
 ]


### PR DESCRIPTION
More details on Chronologic and the DAY token - [https://chronologic.network/](https://chronologic.network/).
Mainnet address: https://etherscan.io/token/0xE814aeE960a85208C3dB542C53E7D4a6C8D5f60F