### PR TITLE
wanchainltd.org

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"wanchainltd.org",
+"www.wanchainltd.org",
 "myetherwallet.caspertestnet.com",
 "caspertestnet.com",
 "wanchainalliance.org",

--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,6 +1,5 @@
 [
 "wanchainltd.org",
-"www.wanchainltd.org",
 "myetherwallet.caspertestnet.com",
 "caspertestnet.com",
 "wanchainalliance.org",


### PR DESCRIPTION
This is a phishing site of wanchain.org used has ico sale, the ethereum address is 0xd9D25DcE4c3765855c76F3d2BAccc0755C4d0bc5

Screenshot: https://i.imgur.com/4q1ItNv.jpg