### PR TITLE
Fix whitelist bug that redirected to warning page

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -167,3 +167,13 @@
     display: none;
     z-index: 1;
 }
+
+#ext-etheraddresslookup-tip_box {
+    background: #00c2c1;
+    padding: 1px;
+    color: #fff;
+}
+#ext-etheraddresslookup-tip_box a {
+    color: #fff;
+    text-decoration: underline;
+}

--- a/js/DomainBlacklist.js
+++ b/js/DomainBlacklist.js
@@ -25,7 +25,8 @@
         });
     }
 
-    function doBlacklistCheck(arrWhitelistedDomains, arrBlacklistedDomains) {
+    function doBlacklistCheck(arrWhitelistedDomains, arrBlacklistedDomains)
+    {
         var strCurrentTab = window.location.hostname;
         strCurrentTab = strCurrentTab.replace(/www\./g,'');
 
@@ -47,6 +48,11 @@
                 var intHolisticMetric = levenshtein(source, 'myetherwallet');
                 var intHolisticLimit = 7 // How different can the word be?
                 blHolisticStatus = (intHolisticMetric > 0 && intHolisticMetric < intHolisticLimit) ? true : false;
+                if(blHolisticStatus === false) {
+                    //Do edit distance against mycrypto
+                    var intHolisticMetric = levenshtein(source, 'mycrypto');
+                    blHolisticStatus = (intHolisticMetric > 0 && intHolisticMetric < intHolisticLimit) ? true : false;
+                }
             }
 
             //If it's not in the whitelist and it is blacklisted or levenshtien wants to blacklist it.

--- a/js/DomainBlacklist.js
+++ b/js/DomainBlacklist.js
@@ -30,7 +30,7 @@
         strCurrentTab = strCurrentTab.replace(/www\./g,'');
 
         //Domain is whitelisted, don't check the blacklist.
-        if(arrWhitelistedDomains.indexOf(strCurrentTab) >= 0 || strCurrentTab === "myetherwallet.com") {
+        if(arrWhitelistedDomains.indexOf(strCurrentTab) >= 0) {
             console.log("Domain "+ strCurrentTab +" is whitelisted on EAL!");
             return false;
         }

--- a/js/options.js
+++ b/js/options.js
@@ -171,7 +171,7 @@ function getBlacklistedDomains(strType)
         //Check to see if the cache is older than 5 minutes, if so re-cache it.
         objBlacklistedDomains = JSON.parse(objBlacklistedDomains);
         console.log("Domains last fetched: " + (Math.floor(Date.now() / 1000) - objBlacklistedDomains.timestamp) + " seconds ago");
-        if (objBlacklistedDomains.timestamp == 0 || (Math.floor(Date.now() / 1000) - objBlacklistedDomains.timestamp) > 180) {
+        if (objBlacklistedDomains.timestamp == 0 || (Math.floor(Date.now() / 1000) - objBlacklistedDomains.timestamp) > 300) {
             updateAllBlacklists(objEalBlacklistedDomains);
         }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "EtherAddressLookup",
   "short_name": "EtherAddressLookup",
   "description": "Adds links to strings that look like Ethereum addresses to your favorite blockchain explorer.",
-  "version": "1.14.1",
+  "version": "1.14.2",
 
   "browser_action": {
     "default_icon": "images/icon.png",

--- a/options.html
+++ b/options.html
@@ -78,7 +78,9 @@
         <a href="https://harrydenley.com/ethaddresslookup-chrome-extension-release/" target="_blank">Read Author Blog</a> &mdash;
         <a href="https://twitter.com/EthAddrLookup" target="_blank">@EthAddrLookup</a>
         <br/>
-        <strong>Tip:</strong> Install our other extension: <a href="https://harrydenley.com/ethsecuritylookup-chrome-extension-release/" target="_blank">EtherSecurityLookup</a>.
+        <span id="ext-etheraddresslookup-tip_box">
+            <strong>Tip:</strong> Install our other extension: <a href="https://harrydenley.com/ethsecuritylookup-chrome-extension-release/" target="_blank">EtherSecurityLookup</a>.
+        </span>
         <br />
         <strong>Version:</strong> <span id="ext-manifest_version"></span> &mdash; BETA
     </div>

--- a/options.html
+++ b/options.html
@@ -42,8 +42,6 @@
         </small>
     </div>
 
-    <br/>
-
     <label>Preferred Blockchain Explorer</label>
     <select class="form-control" name="ext-etheraddresslookup-choose_blockchain"
             id="ext-etheraddresslookup-choose_blockchain">
@@ -75,11 +73,13 @@
             <a href="https://github.com/409H/EtherAddressLookup" target="_blank">GitHub</a>
         </div>
 
-        <hr />
+        <br />
 
         <a href="https://harrydenley.com/ethaddresslookup-chrome-extension-release/" target="_blank">Read Author Blog</a> &mdash;
         <a href="https://twitter.com/EthAddrLookup" target="_blank">@EthAddrLookup</a>
         <br/>
+        <strong>Tip:</strong> Install our other extension: <a href="https://harrydenley.com/ethsecuritylookup-chrome-extension-release/" target="_blank">EtherSecurityLookup</a>.
+        <br />
         <strong>Version:</strong> <span id="ext-manifest_version"></span> &mdash; BETA
     </div>
 </div>


### PR DESCRIPTION
* Re-arranged blacklisting/whitelisting check logic.
* Converted the `getWhitelistedDomainsFromSource()` method to async returning a promise.
* Whitelistes will refresh every 300 seconds.

Fixes https://github.com/409H/EtherAddressLookup/issues/262