### PR TITLE
Blacklist decentral.market

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -874,6 +874,7 @@
 "cryptoalliance.herokuapp.com",
 "decentraland.pro",
 "decentraland.tech",
+"decentral.market",
 "digitaldevelopersfund.vacau.com",
 "district-0x.io",
 "district0x.net",


### PR DESCRIPTION
decentral.market is a fake cryptocurrency news website that posts articles from other sites. When it copies ICO participation guides, it replaces the contribution address with a different address.

Example: [Arcblock](https://decentral.market/2018/02/03/how-to-participate-in-arcblock-token-sale/) and [Republic Protocol](https://decentral.market/2018/02/03/how-to-participate-in-republic-protocol-crowdsale/) have the same Ethereum address (0xdefb014b9e2f3bd81cdb084821f99b681cfca695).

https://urlscan.io/result/13e72351-ec0c-4ea0-89b4-c2b9e3031197#summary