### PR TITLE
Adding fusion-ico.com to blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"fusion-ico.com",
 "trx.foundation",
 "tokensale.adhive.net",
 "adhive.net",


### PR DESCRIPTION
Adding fusion-ico.com to blacklist. See https://urlscan.io/result/a5711040-fdd0-4a4c-b3d4-1b4ff6e96924#summary. The valid link is https://fusion.org/.