### PR TITLE
Adding fusion.tokencrowdsale.online to blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"fusion.tokencrowdsale.online",
 "trx.foundation",
 "tokensale.adhive.net",
 "adhive.net",


### PR DESCRIPTION
See https://urlscan.io/result/04cd85b7-6530-4944-af28-197cdee50eb3#summary. The actual site, https://fusion.org/.