### PR TITLE
xn--coindek-873c.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -23,7 +23,7 @@
 "address-transfer-confirmation.droppages.com",
 "xn--metherwalle-jb9ejq.com",
 "xn--coindek-s73c.com",
-"xn--coindek-873c.com/",
+"xn--coindek-873c.com",
 "p.b5z.net",
 "b5z.net",
 "havven.cc",

--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -23,6 +23,7 @@
 "address-transfer-confirmation.droppages.com",
 "xn--metherwalle-jb9ejq.com",
 "xn--coindek-s73c.com",
+"xn--coindek-873c.com/",
 "p.b5z.net",
 "b5z.net",
 "havven.cc",


### PR DESCRIPTION
New coindesk phishing site - https://www.xn--coindek-873c.com/ (appears as https://coindeşk.com/ - mind the "ş"!)