### PR TITLE
Salt Lending airdrop phishing in google forms

### DIFF
--- a/blacklists/uri.json
+++ b/blacklists/uri.json
@@ -1,5 +1,6 @@
 [
 "twitter.com/OmiseG0",
 "twitter.com/ethereumwallets",
-"twitter.com/omise__go"
+"twitter.com/omise__go",
+"docs.google.com/forms/d/e/1FAIpQLSdmOYxXTAm6-teLVg58OAM0M2PsN17K8gw6Dm3PaBZTeD_RFQ/viewform"
 ]


### PR DESCRIPTION
Fake Airdrop for Salt Lending.
![image](https://user-images.githubusercontent.com/32845920/37107052-87d1ee0c-21f0-11e8-9710-586b61d11307.png)
