### PR TITLE
Adding meteorwallet.xyz to whitelist

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -1,4 +1,5 @@
 [
+"meteorwallet.xyz",
 "yelp.com",
 "huobipro.com",
 "withdrawal.net",


### PR DESCRIPTION
My website about my stellar lumens wallet is getting flagged, I assume as it has a donation address at the bottom of the page. It's a static page though just linking to the play store, it doesn't capture anything from users and donating is totally optional.