### PR TITLE
Implement debugging mode & console logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ a [pull request](https://github.com/409H/EtherAddressLookup/compare) with the ch
 * Thanks to [Samyoul](https://github.com/Samyoul) for continued support and development!
 * To everyone who reports bad domains to us through the various channels!
 
+## Debugging
+
+To enable debugging you need to create a cookie called `eal_debug` on the desired host you're debugging. Debugging provides additional output regarding internals of the EtherAddressLookup plugin.
+
 ----
 
 ## Changelog

--- a/js/DomManipulator.js
+++ b/js/DomManipulator.js
@@ -4,7 +4,7 @@ class EtherAddressLookup {
 
     constructor(objWeb3)
     {
-        console.log("Init EAL");
+        consoleLogger.log("Init EAL");
         this.objWeb3 = objWeb3;
         this.setDefaultExtensionSettings();
         this.init();

--- a/js/DomainBlacklist.js
+++ b/js/DomainBlacklist.js
@@ -32,7 +32,7 @@
 
         //Domain is whitelisted, don't check the blacklist.
         if(arrWhitelistedDomains.indexOf(strCurrentTab) >= 0) {
-            console.log("Domain "+ strCurrentTab +" is whitelisted on EAL!");
+            consoleLogger.log("Domain "+ strCurrentTab +" is whitelisted on EAL!");
             return false;
         }
 
@@ -57,7 +57,7 @@
 
             //If it's not in the whitelist and it is blacklisted or levenshtien wants to blacklist it.
             if ( arrWhitelistedDomains.indexOf(strCurrentTab) < 0 && (isBlacklisted === true || blHolisticStatus === true)) {
-                console.warn(window.location.href + " is blacklisted by EAL - "+ (isBlacklisted ? "Blacklisted" : "Levenshtein Logic"));
+                consoleLogger.warn(window.location.href + " is blacklisted by EAL - "+ (isBlacklisted ? "Blacklisted" : "Levenshtein Logic"));
                 window.location.href = "https://harrydenley.com/EtherAddressLookup/phishing.html#"+ (window.location.href);
                 return false;
             }
@@ -80,7 +80,7 @@
                                 }
 
                                 if(obj3rdPartyLists[str3rdPartyIdentifier].domains.indexOf(strCurrentTab) >= 0) {
-                                    console.warn(window.location.href + " is blacklisted by "+ str3rdPartyIdentifier);
+                                    consoleLogger.warn(window.location.href + " is blacklisted by "+ str3rdPartyIdentifier);
                                     window.location.href = "https://harrydenley.com/EtherAddressLookup/phishing-"+ str3rdPartyIdentifier +".html#"+ (window.location.href);
                                     return false;
                                 }

--- a/js/app/chooseBlockchain.js
+++ b/js/app/chooseBlockchain.js
@@ -25,7 +25,7 @@ function refreshBlockchainExplorer() {
         chrome.tabs.sendMessage(tabs[0].id, {
             "func":strMethod
         }, function(response) {
-            console.log(response);
+            consoleLogger.log(response);
         });
     });
 }

--- a/js/app/consoleLogger.js
+++ b/js/app/consoleLogger.js
@@ -1,0 +1,43 @@
+class ConsoleLogger {
+    /**
+     * Determine if eal_debug cookie is set
+     */
+    get debug() {
+        return !!document.cookie.match(/^(.*;)?\s*eal_debug\s*=\s*[^;]+(.*)?$/);
+    }
+
+    /**
+     * Log a message to the console 
+     * 
+     * @param {*} args 
+     */
+    log(...args) {
+        if (this.debug) {
+            console.log.apply(this, args);
+        }
+    }
+
+    /**
+     * Log a warning message to the console
+     * 
+     * @param {*} args 
+     */
+    warn(...args) {
+        if (this.debug) {
+            console.warn.apply(this, args);
+        }
+    }
+
+    /**
+     * Log an error message to the console
+     * 
+     * @param {*} args 
+     */
+    error(...args) {
+        if (this.debug) {
+            console.error.apply(this, args);
+        }
+    }
+}
+
+const consoleLogger = new ConsoleLogger();

--- a/js/app/historyInspector.js
+++ b/js/app/historyInspector.js
@@ -13,7 +13,7 @@
                     permissions: ['history']
                 }, function (blGranted) {
                     if (blGranted) {
-                        console.log("Granted history permission");
+                        consoleLogger.log("Granted history permission");
                         doHistoryInspection();
                     } else {
                         exitNoPermission();
@@ -92,9 +92,9 @@ function removePermission()
         permissions: ['history']
     }, function(removed) {
         if (removed) {
-            console.log("Removed history permission.")
+            consoleLogger.log("Removed history permission.")
         } else {
-            console.log("Cannot remove history permission!");
+            consoleLogger.log("Cannot remove history permission!");
         }
     });
 }

--- a/js/app/rpcNodeSelector.js
+++ b/js/app/rpcNodeSelector.js
@@ -68,7 +68,7 @@ class RpcNodeSelector
         var objRpcSuccessNode = document.getElementById("ext-etheraddresslookup-rpcnode_success");
         objRpcSuccessNode.classList.remove("hide-me");
 
-        console.log("RPC Node Version: "+ strVersion);
+        consoleLogger.log("RPC Node Version: "+ strVersion);
         return true;
     }
 

--- a/js/app/toggleBlacklistDomains.js
+++ b/js/app/toggleBlacklistDomains.js
@@ -30,7 +30,7 @@ function toggle3rdPartyBlacklistDomains()
 function refreshBlacklistDomains()
 {
     chrome.runtime.sendMessage({func: "blacklist_domain_list"}, function(objResponse) {
-        console.log("BDL-001");
+        consoleLogger.log("BDL-001");
     });
 
     var intBlacklistDomains = localStorage.getItem("ext-etheraddresslookup-blacklist_domains");

--- a/js/app/toggleMatchHighlight.js
+++ b/js/app/toggleMatchHighlight.js
@@ -21,7 +21,7 @@ function refreshHighlightOption() {
         chrome.tabs.sendMessage(tabs[0].id, {
             "func":strMethod
         }, function(response) {
-            console.log(response);
+            consoleLogger.log(response);
         });
     });
 }

--- a/js/options.js
+++ b/js/options.js
@@ -40,13 +40,13 @@ let objBrowser = chrome ? chrome : browser;
     //init getting blacklisted domains
     getBlacklistedDomains();
     setInterval(function() {
-        console.log("Re-caching blacklisted domains");
+        consoleLogger.log("Re-caching blacklisted domains");
         getBlacklistedDomains();
     }, 180000);
 
     getWhitelistedDomains();
     setInterval(function() {
-        console.log("Re-caching whitelisted domains");
+        consoleLogger.log("Re-caching whitelisted domains");
         getWhitelistedDomains();
     }, 180000);
 })();
@@ -83,11 +83,11 @@ objBrowser.runtime.onMessage.addListener(
                 }
                 break;
             case 'blacklist_domain_list' :
-                console.log("Getting blacklisted domain list");
+                consoleLogger.log("Getting blacklisted domain list");
                 strResponse = getBlacklistedDomains("eal");
                 break;
             case '3p_blacklist_domain_list' :
-                console.log("Getting 3p blacklisted domain list");
+                consoleLogger.log("Getting 3p blacklisted domain list");
                 strResponse = getBlacklistedDomains("3p");
                 break;
             case 'use_3rd_party_blacklists' :
@@ -99,7 +99,7 @@ objBrowser.runtime.onMessage.addListener(
                 }
                 break;
             case 'whitelist_domain_list' :
-                console.log("Getting whitelisted domain list");
+                consoleLogger.log("Getting whitelisted domain list");
                 strResponse = getWhitelistedDomains();
                 break;
             case 'rpc_provider' :
@@ -170,7 +170,7 @@ function getBlacklistedDomains(strType)
         var objBlacklistedDomains = localStorage.getItem("ext-etheraddresslookup-blacklist_domains_list");
         //Check to see if the cache is older than 5 minutes, if so re-cache it.
         objBlacklistedDomains = JSON.parse(objBlacklistedDomains);
-        console.log("Domains last fetched: " + (Math.floor(Date.now() / 1000) - objBlacklistedDomains.timestamp) + " seconds ago");
+        consoleLogger.log("Domains last fetched: " + (Math.floor(Date.now() / 1000) - objBlacklistedDomains.timestamp) + " seconds ago");
         if (objBlacklistedDomains.timestamp == 0 || (Math.floor(Date.now() / 1000) - objBlacklistedDomains.timestamp) > 300) {
             updateAllBlacklists(objEalBlacklistedDomains);
         }
@@ -230,9 +230,9 @@ function getWhitelistedDomains()
         var objWhitelistedDomains = localStorage.getItem("ext-etheraddresslookup-whitelist_domains_list");
         //Check to see if the cache is older than 5 minutes, if so re-cache it.
         objWhitelistedDomains = JSON.parse(objWhitelistedDomains);
-        console.log("Whitelisted domains last fetched: " + (Math.floor(Date.now() / 1000) - objWhitelistedDomains.timestamp) + " seconds ago");
+        consoleLogger.log("Whitelisted domains last fetched: " + (Math.floor(Date.now() / 1000) - objWhitelistedDomains.timestamp) + " seconds ago");
         if ((Math.floor(Date.now() / 1000) - objWhitelistedDomains.timestamp) > 300) {
-            console.log("Caching whitelisted domains again.");
+            consoleLogger.log("Caching whitelisted domains again.");
             getWhitelistedDomainsFromSource().then(function (arrDomains) {
                 objWhitelistedDomains.timestamp = Math.floor(Date.now() / 1000);
                 objWhitelistedDomains.domains = arrDomains;
@@ -249,23 +249,23 @@ function getWhitelistedDomains()
 async function getBlacklistedDomainsFromSource(objBlacklist)
 {
     try {
-        console.log("Getting blacklist from GitHub now: "+ objBlacklist.repo);
+        consoleLogger.log("Getting blacklist from GitHub now: "+ objBlacklist.repo);
         let objResponse = await fetch(objBlacklist.repo);
         return objResponse.json();
     }
     catch(objError) {
-        console.log("Failed to get blacklist for "+ objBlacklist.repo, objError);
+        consoleLogger.log("Failed to get blacklist for "+ objBlacklist.repo, objError);
     }
 }
 
 async function getWhitelistedDomainsFromSource()
 {
     try {
-        console.log("Getting whitelist from GitHub now: https://raw.githubusercontent.com/409H/EtherAddressLookup/master/whitelists/domains.json");
+        consoleLogger.log("Getting whitelist from GitHub now: https://raw.githubusercontent.com/409H/EtherAddressLookup/master/whitelists/domains.json");
         let objResponse = await fetch("https://raw.githubusercontent.com/409H/EtherAddressLookup/master/whitelists/domains.json");
         return objResponse.json();
     }
     catch(objError) {
-        console.log("Failed to get whitelist for https://raw.githubusercontent.com/409H/EtherAddressLookup/master/whitelists/domains.json", objError);
+        consoleLogger.log("Failed to get whitelist for https://raw.githubusercontent.com/409H/EtherAddressLookup/master/whitelists/domains.json", objError);
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,7 @@
     "run_at": "document_start",
     "matches": ["http://*/*", "https://*/*"],
     "js": [
+      "js/app/consoleLogger.js",
       "js/app/lib/punycode.min.js",
       "js/app/lib/blockies.min.js",
       "js/app/lib/sha256.min.js",
@@ -40,7 +41,7 @@
   }],
 
   "background": {
-    "scripts": ["js/options.js"]
+    "scripts": ["js/app/consoleLogger.js","js/options.js"]
   },
 
   "icons": {


### PR DESCRIPTION
I don't believe Chrome / Firefox extensions should *always* log to the console, as it'll provide confusion & additional mess for developers working on other projects with the plugin enabled. 

This PR implements a new `ConsoleLogger` class which is imported into the various aspects of the extension. I've also replaced all calls to `console.log` and `console.warn` in the plugins files (not lib) to `consoleLogger.log` and `consoleLogger.warn`.

To enable debugging you simply need to set a cookie called `eal_debug` on the domain you wish to debug upon. This will then log the messages prior to this PR.

