### PR TITLE
zycrypto.com & crypto.cat

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -1,4 +1,5 @@
 [
+"crypto.cat",
 "zycrypto.com",
 "meteorwallet.xyz",
 "yelp.com",

--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -1,4 +1,5 @@
 [
+"zycrypto.com",
 "meteorwallet.xyz",
 "yelp.com",
 "huobipro.com",


### PR DESCRIPTION
False-positive blacklist

https://urlscan.io/result/69e2e9a1-1897-4342-a71e-d47dbb104c08#summary

Fixes https://github.com/409H/EtherAddressLookup/issues/362