### PR TITLE
Adding ethopen.com into the blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"ethopen.com",
 "telegram.ceo",
 "etherscan-giveaway.epizy.com",
 "eths.bz",


### PR DESCRIPTION
See link, https://urlscan.io/result/e64c78b2-c870-4ca1-9fd9-002c2d49237c#summary.