### PR TITLE
Adding telegramnetwork.org into blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"telegramnetwork.org",
 "telegram.ceo",
 "etherscan-giveaway.epizy.com",
 "eths.bz",


### PR DESCRIPTION
See link, https://urlscan.io/result/cfa1c0a9-437e-4cf1-8ae9-9296cc2f74b5#summary.