### PR TITLE
ethen.market whitelisted

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -168,5 +168,6 @@
 "www.maecenas.co",
 "www.polyswarm.io",
 "polyswarm.io",
-"tokensale.polyswarm.io"
+"tokensale.polyswarm.io",
+"ethen.market"
 ]


### PR DESCRIPTION
And btw distance [intHolisticLimit = 7](https://github.com/409H/EtherAddressLookup/blob/master/js/DomainBlacklist.js#L49) is _huge_.
For example distance between `myabcdewallet` and `myetherwallet` is only 5.