### PR TITLE
Adding myegemwallet.com + egem.io  to whitelist

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -172,4 +172,6 @@
 "www.polyswarm.io",
 "polyswarm.io",
 "tokensale.polyswarm.io"
+"myegemwallet.com"
+"egem.io"
 ]

--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -171,7 +171,7 @@
 "www.maecenas.co",
 "www.polyswarm.io",
 "polyswarm.io",
-"tokensale.polyswarm.io"
-"myegemwallet.com"
+"tokensale.polyswarm.io",
+"myegemwallet.com",
 "egem.io"
 ]


### PR DESCRIPTION
Hello, 

We are a new coin launching on the 31st of this month. 

Hello,

This is incorrect. https://myegemwallet.com/ is not a fake - it is our live site for EGEM wallet.

We are launching EGEM on the 31st.

https://github.com/TeamEGEM
https://egem.io

Please contact us for more info.

Thanks,

TeamEGEM

https://github.com/409H/EtherAddressLookup/issues/399