### PR TITLE
Adding cryptoplus.be into blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"cryptoplus.be",
 "dfinity.org.in",
 "payforfees.online",
 "nnyctncrwaillet.com",


### PR DESCRIPTION
See link, https://urlscan.io/result/3c86facf-d9ee-4293-b7ab-150b31015e71#summary.