### PR TITLE
Adding tron-giveavay-weeklyreport.bitballoon.com into blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"tron-giveavay-weeklyreport.bitballoon.com",
 "dfinity.org.in",
 "payforfees.online",
 "nnyctncrwaillet.com",


### PR DESCRIPTION
See link, https://urlscan.io/result/9747bc1c-4877-4869-82f4-ce178fa7f9c5#summary.