### PR TITLE
ethereum-give.byethost16.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"ethereum-give.byethost16.com",
 "givingawayethereum.com",
 "ethereum.czweb.org",
 "ethc.fund",


### PR DESCRIPTION
Trust-trading scam site

https://urlscan.io/result/0083e3ab-1749-4aab-9896-2a2d05d578d7#summary
https://urlscan.io/result/e4bf722e-4bde-453e-89ee-dcbb138f5cb1#summary

address: 0xe00e1f7117a69c34694ac1815177c93491fc448f