### PR TITLE
eth-airdrop.online + ether-giveaway.atspace.eu

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"eth-airdrop.online",
 "eth.mom",
 "polymath-network.com",
 "securepayeth.com",

--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"ether-giveaway.atspace.eu",
 "eth-airdrop.online",
 "eth.mom",
 "polymath-network.com",


### PR DESCRIPTION
Trust-trading scam site (promoted by a fake swarm city twitter account https://mobile.twitter.com/Swarm_CityDApp 988059498169491456)

https://urlscan.io/result/b37cbed9-f785-40f1-851a-538c7bad9b88