### PR TITLE
Added work.nelsconsult.com.ng

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -6602,5 +6602,6 @@
 "xn--myethewalet-ms8erq.com",
 "xn--mytherwalet-ms8e53d.com",
 "xn--crpto-rva.com",
-"xn--cypt-8qa.com"
+"xn--cypt-8qa.com",
+"work.nelsconsult.com.ng"
 ]


### PR DESCRIPTION
Phishing site from scraping of our company website.  This is just yet another iteration from what we believe is the same group behind the attacks on SALT Lending.