### PR TITLE
i-idex.market + forkdelta.net

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"i-idex.market",
+"forkdelta.net",
 "kinecosystem.io",
 "quark-chain.io",
 "quarkchain.org",


### PR DESCRIPTION
i-idex.market
Fake Idex phishing for private keys. Sends off to POST http://176[.]122[.]20[.]15/sendkey
https://urlscan.io/result/5afc9f77-2d82-405e-956c-691432b92f78/
https://urlscan.io/result/23d70a91-6aee-436d-8145-b7451adaff37/

forkdelta.net
Fake ForkDelta GUI
https://urlscan.io/result/51dee6ed-de25-44ce-b2b1-cd33b9a59849/