### PR TITLE
Blacklist punycode domains

### DIFF
--- a/js/DomainBlacklist.js
+++ b/js/DomainBlacklist.js
@@ -27,10 +27,24 @@
 
     function doBlacklistCheck(arrWhitelistedDomains, arrBlacklistedDomains)
     {
-        var strCurrentTab = window.location.hostname;
-        strCurrentTab = strCurrentTab.replace(/www\./g,'');
+        //See if we are blocking all punycode domains.
+        objBrowser.runtime.sendMessage({func: "block_punycode_domains"}, function(objResponse) {
+            if(objResponse && objResponse.hasOwnProperty("resp")) {
+                var strCurrentTab = window.location.hostname;
+                var strCurrentTab = strCurrentTab.replace(/www\./g,'');
+
+                if(objResponse.resp == 1) {
+                    if(strCurrentTab.startsWith("xn--")) {
+                        window.location.href = "https://harrydenley.com/EtherAddressLookup/phishing.html#"+ (window.location.href)+"#punycode";
+                        return false;
+                    }
+                }
+            }
+        });
 
         //Domain is whitelisted, don't check the blacklist.
+        var strCurrentTab = window.location.hostname;
+        strCurrentTab = strCurrentTab.replace(/www\./g,'');
         if(arrWhitelistedDomains.indexOf(strCurrentTab) >= 0) {
             console.log("Domain "+ strCurrentTab +" is whitelisted on EAL!");
             return false;

--- a/js/DomainBlacklist.js
+++ b/js/DomainBlacklist.js
@@ -63,7 +63,7 @@
                 var strCurrentTab = punycode.toUnicode(strCurrentTab);
                 var source = strCurrentTab.replace(/\./g, '');
                 var intHolisticMetric = levenshtein(source, 'myetherwallet');
-                var intHolisticLimit = 7 // How different can the word be?
+                var intHolisticLimit = 5; // How different can the word be?
                 blHolisticStatus = (intHolisticMetric > 0 && intHolisticMetric < intHolisticLimit) ? true : false;
                 if(blHolisticStatus === false) {
                     //Do edit distance against mycrypto

--- a/js/DomainBlacklist.js
+++ b/js/DomainBlacklist.js
@@ -75,7 +75,7 @@
             //If it's not in the whitelist and it is blacklisted or levenshtien wants to blacklist it.
             if ( arrWhitelistedDomains.indexOf(strCurrentTab) < 0 && (isBlacklisted === true || blHolisticStatus === true)) {
                 console.warn(window.location.href + " is blacklisted by EAL - "+ (isBlacklisted ? "Blacklisted" : "Levenshtein Logic"));
-                window.location.href = "https://harrydenley.com/EtherAddressLookup/phishing.html#"+ (window.location.href);
+                window.location.href = "https://harrydenley.com/EtherAddressLookup/phishing.html#"+ (window.location.href) +"#"+ (isBlacklisted ? "blacklisted" : "levenshtein");
                 return false;
             }
         }

--- a/js/DomainBlacklist.js
+++ b/js/DomainBlacklist.js
@@ -34,10 +34,13 @@
                 var strCurrentTab = strCurrentTab.replace(/www\./g,'');
 
                 if(objResponse.resp == 1) {
-                    if(strCurrentTab.startsWith("xn--")) {
-                        window.location.href = "https://harrydenley.com/EtherAddressLookup/phishing.html#"+ (window.location.href)+"#punycode";
-                        return false;
-                    }
+                    var arrDomainParts = strCurrentTab.split(".");
+                    arrDomainParts.forEach(strDomainPart => {
+                        if (strDomainPart.startsWith("xn--")) {
+                            window.location.href = "https://harrydenley.com/EtherAddressLookup/phishing.html#" + (window.location.href) + "#punycode";
+                            return false;
+                        }
+                    });
                 }
             }
         });

--- a/js/app/toggleBlacklistDomains.js
+++ b/js/app/toggleBlacklistDomains.js
@@ -27,6 +27,16 @@ function toggle3rdPartyBlacklistDomains()
     refreshBlacklistDomains();
 }
 
+//Sets the local storage to remember if we are blocking all punycode domains or not
+function toggleBlockPunycodeDomains()
+{
+    var objBlockPunycodeDomains = document.getElementById("ext-etheraddresslookup-block_punycode_blacklist_domains");
+    var intBlockPunycodeDomains = objBlockPunycodeDomains.checked ? 1 : 0;
+    localStorage.setItem("ext-etheraddresslookup-block_punycode_blacklist_domains", intBlockPunycodeDomains);
+
+    refreshBlacklistDomains();
+}
+
 function refreshBlacklistDomains()
 {
     var objBrowser = chrome ? chrome : browser;
@@ -48,6 +58,14 @@ function refreshBlacklistDomains()
         document.getElementById("ext-etheraddresslookup-3rd_party_blacklist_domains").checked = true;
     } else {
         document.getElementById("ext-etheraddresslookup-3rd_party_blacklist_domains").checked = (intUse3rdPartyBlacklists == 1 ? true : false);
+    }
+
+    //Check/uncheck use block punycode domains
+    var intBlockPunycodeDomains = localStorage.getItem("ext-etheraddresslookup-block_punycode_blacklist_domains");
+    if(intBlockPunycodeDomains === null) {
+        document.getElementById("ext-etheraddresslookup-block_punycode_blacklist_domains").checked = true;
+    } else {
+        document.getElementById("ext-etheraddresslookup-block_punycode_blacklist_domains").checked = (intBlockPunycodeDomains == 1 ? true : false);
     }
 }
 

--- a/js/options.js
+++ b/js/options.js
@@ -30,6 +30,12 @@ let objBrowser = chrome ? chrome : browser;
         objBlacklistDomains.addEventListener('click', toggle3rdPartyBlacklistDomains);
     }
 
+    //Toggle the use of blacklisting all punycode domains and set it in LocalStorage
+    var objBlacklistPunycodeDomains = document.getElementById('ext-etheraddresslookup-block_punycode_blacklist_domains');
+    if(objBlacklistPunycodeDomains) {
+        objBlacklistPunycodeDomains.addEventListener('click', toggleBlockPunycodeDomains);
+    }
+
     //Get the extension version
     var objManifest = objBrowser.runtime.getManifest();
     var objManifestVersion = document.getElementById('ext-manifest_version');
@@ -96,6 +102,14 @@ objBrowser.runtime.onMessage.addListener(
                     strResponse = 1;
                 } else {
                     strResponse = localStorage.getItem("ext-etheraddresslookup-use_3rd_party_blacklist");
+                }
+                break;
+            case 'block_punycode_domains' :
+                //This option is enabled by default
+                if(localStorage.getItem("ext-etheraddresslookup-block_punycode_blacklist_domains") === null) {
+                    strResponse = 1;
+                } else {
+                    strResponse = localStorage.getItem("ext-etheraddresslookup-block_punycode_blacklist_domains");
                 }
                 break;
             case 'whitelist_domain_list' :

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "EtherAddressLookup",
   "short_name": "EtherAddressLookup",
   "description": "Adds links to strings that look like Ethereum addresses to your favorite blockchain explorer.",
-  "version": "1.15.1",
+  "version": "1.16",
 
   "browser_action": {
     "default_icon": "images/icon.png",

--- a/options.html
+++ b/options.html
@@ -34,13 +34,16 @@
         <span>Warn of blacklisted domains</span>
     </label>
     <div id="ext-etheraddresslookup-blacklist_domains_stats">
-        <input type="checkbox" name="ext-etheraddresslookup-3rd_party_blacklist_domains" id="ext-etheraddresslookup-3rd_party_blacklist_domains"> Use 3rd party blacklists <br /> <br />
+        <input type="checkbox" name="ext-etheraddresslookup-3rd_party_blacklist_domains" id="ext-etheraddresslookup-3rd_party_blacklist_domains"> Use 3rd party blacklists <br />
+        <input type="checkbox" name="ext-etheraddresslookup-block_punycode_blacklist_domains" id="ext-etheraddresslookup-block_punycode_blacklist_domains"> Block all punycode domains <br /> <br />
         <small>Last updated: <span id="ext-etheraddresslookup-blacklist_domains_last_updated">N/A</span></small>
         <br/>
         <small>Domains Blacklisted: <span id="ext-etheraddresslookup-blacklist_domains_total_count">0</span>
                                     (<span id="ext-etheraddresslookup-3p_blacklist_domains_total_count">0</span>)
         </small>
     </div>
+
+    <br />
 
     <label>Preferred Blockchain Explorer</label>
     <select class="form-control" name="ext-etheraddresslookup-choose_blockchain"
@@ -65,7 +68,6 @@
         <small>* ENS address compatible.</small>
     </div>
 
-    <br/>
     <div id="footer">
         <div class="ext-etheraddresslookup-center">
             <a href="/settings.html" target="_blank">More Settings</a> &mdash;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etheraddresslookup",
-  "version": "1.15.1",
+  "version": "1.16",
   "description": "A web extension for blocking ethereum phishing websites.",
   "main": "blacklists/domains.json",
   "scripts": {


### PR DESCRIPTION
* Added logic to blacklist all punycode domains. This will help tackle phishing in a big way as we are seeing a lot of IDN homograph attack domains on places such as coinbase, poloniex, mycrypto, and myetherwallet.
  * This block is toggable, but by default it's turned on.
* Adjusted edit distance for `myetherwallet.com` from 7 to 5 to prevent a lot of false-positives.