### PR TITLE
giveawayethereum.win + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,13 @@
 [
+"giveawayethereum.win",
+"myetherwallet.accountant",
+"myetherwallat.date",
+"myethervvallet.win",
+"myethcrwallet-d.com",
+"myethcrwallet-c.com",
+"myethcrwallet-b.com",
+"myethcrwallct-a.com",
+"myeterwallct-p.com",
 "collect.ethforyou.com",
 "ethforyou.com",
 "getmyetho.paperplane.io",


### PR DESCRIPTION
giveawayethereum.win
Trust-trading scam site
https://urlscan.io/result/8b714acc-b0c5-40b2-b610-9e629235243e
address: 0x8aF1380c436fC019b8055C61d09e3Ee5F182278C

myeterwallct-p.com
Suspect MyEtherWallet domain
https://urlscan.io/result/01b8f66b-75fe-47a7-8f17-e6f73aab0a93/

myethcrwallct-a.com
Suspect MyEtherWallet domain
https://urlscan.io/result/8d595bf4-53bd-457e-891d-649615f23194/

myethcrwallet-b.com
Suspect MyEtherWallet domain
https://urlscan.io/result/f0ce5269-8a2f-4492-a234-7c3fddec5fb3/

myethcrwallet-c.com
Suspect MyEtherWallet domain
https://urlscan.io/result/91f96f57-dc2d-4b81-aa04-1ae60746eb88/

myethcrwallet-d.com
Suspect MyEtherWallet domain
https://urlscan.io/result/438d36e6-12a5-472f-bda2-942a906f82ed/

myethervvallet.win
Suspect MyEtherWallet domain
https://urlscan.io/result/d870bf50-dc6e-4fd8-bec3-56a8eabe6526/

myetherwallat.date
Suspect MyEtherWallet domain
https://urlscan.io/result/39afad60-5448-4c77-9c6c-42ffa55f7444/

myetherwallet.accountant
Suspect MyEtherWallet domain
https://urlscan.io/result/c3340e42-a438-4b04-9ee4-0a5f24686115/