### PR TITLE
xn--bifinex-fb4c.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,9 @@
 [
+"xn--bifinex-fb4c.com",
+"xn--blockcain-g95d.com",
+"xn--coinbas-z8a.info",
+"xn--htbt-3oa0a.com",
+"xn--myethewallt-crb9748g.com",
 "xn--polonix-17a.com",
 "xn--tro-k5y.com",
 "privcoin.io",


### PR DESCRIPTION
xn--bifinex-fb4c.com
Fake Bitfinex promoting a fake giveaway (trust-trading) - IDN homograph attack domain
https://urlscan.io/result/3e2af687-b705-4fb5-9e77-b8b55e073ae4/
https://urlscan.io/result/551eb57d-2c7c-4121-a9dc-ebdc789fe2df/
https://urlscan.io/result/e6e98a26-177a-4a17-8fbc-c7f1e7312c96/
address:  0x09430a9Fb46a1a3B83980768C4cEDF654d8eefa3

xn--blockcain-g95d.com
Fake blockchain domain - IDN homograph attack domain
https://urlscan.io/result/d6155859-055a-40be-991f-8ced9eb5cd01/

xn--coinbas-z8a.info
Fake coinbase domain - IDN homograph attack domain
https://urlscan.io/result/e203d686-3164-44e9-8056-30e652ef36d2/

xn--htbt-3oa0a.com
Fake Hitbtc domain - IDN homograph attack domain
https://urlscan.io/result/b48afb7a-3133-4761-9ec3-a7b62cd0848e/

xn--tbtc-upa94a.com
Fake Hitbtc domain - IDN homograph attack domain
https://urlscan.io/result/78933357-c1b4-4af8-a62b-fb28014740da/

xn--myethewallt-crb9748g.com
Fake MyEtherWallet domain - IDN homograph attack domain
https://urlscan.io/result/90fc84ba-e285-43b7-b5bf-c903eadd1339/