### PR TITLE
etherfree.tech

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"etherfree.tech",
 "quarkchain.live",
 "secure-ethereum.tw1.su",
 "phantasma-ico.io",


### PR DESCRIPTION
etherfree.tech
Trust-trading scam site, promoted by twitter userid: 330491787
https://urlscan.io/result/16734e7f-017f-454f-ad29-0a60191e75ee
address: 0x8C9D135aC2778e1A7d326932AaD302e7c22c94D7