### PR TITLE
ethgiveavvay.site

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"ethgiveavvay.site",
 "etherums-givingaway.atspace.tv",
 "etherfree.tech",
 "quarkchain.live",


### PR DESCRIPTION
ethgiveavvay.site
Trust-trading scam site
https://urlscan.io/result/45b3534d-7722-4936-99b5-b4ff382a9d83
address:  0x0C4762Bc7B1Af1DC9448A827f53861c118B712dE