### PR TITLE
Adding quarkchain-presale.io into blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"quarkchain-presale.io",
 "ethgiveavvay.site",
 "etherums-givingaway.atspace.tv",
 "etherfree.tech",


### PR DESCRIPTION
See link, https://urlscan.io/result/f02dddfb-357f-4e0d-9234-e5a77f8da632.