### PR TITLE
quarkchain.pl + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"mycrypto-com.com",
 "quarkchain.pl",
 "get-5001-ethereum.com",
 "get-5000-ethereum.com",

--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,9 @@
 [
+"quarkchain.pl",
+"get-5001-ethereum.com",
+"get-5000-ethereum.com",
+"myetzerwallet.com",
+"promobtc.win",
 "tokenairdrop.typeform.com",
 "transfer.saferpayeth.com",
 "saferpayeth.com",


### PR DESCRIPTION
quarkchain.pl
Fake Quarkchain crowdsale site
https://urlscan.io/result/fa2fa7fb-a09c-4985-a85e-19bbdcb18671/
https://urlscan.io/result/f9631b40-6b5f-4ede-90a6-be1eb1ed04a3/
address: 0x7448dF6E1031d10e237b1481930a074B13FAAbD2

get-5001-ethereum.com
Trust-trading scam site
https://urlscan.io/result/c652c593-7a0f-41a2-85d4-007dc61558af/
address: 0x7D922A4f7F24fFcb130c4EEAF291A6475e3e4Dd2

get-5000-ethereum.com
Trust-trading scam site
https://urlscan.io/result/f2388aad-4a65-482e-ab39-c7a3d3f47c4a/
address: 0x1056d8d9EbB0E0d8710A0E2A1852d4A09d56464A

myetzerwallet.com
Fake MyEtherWallet
https://urlscan.io/result/22749122-afc6-459f-a507-5c419ed9b759/

promobtc.win
Trust-trading scam site (btc) - address: 14h4Zrd1xVg6Mj3JcYApoi2wY2UXue2ETb
https://urlscan.io/result/f065a6cb-24ee-449d-b846-41a1a4dc77fe/