### PR TITLE
Adding icostarex.mipropia.com into blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"icostarex.mipropia.com",
 "waves-ethereum-eth.org",
 "ethereum-eth.life",
 "mycrypto-com.com",


### PR DESCRIPTION
See link, https://urlscan.io/result/0e615e1d-2b7e-44ee-8e59-ad1998d2eeb2 and https://twitter.com/BlqCheds/status/992402297442488320.