### PR TITLE
Adding giveaway-ether.com into blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"giveaway-ether.com",
 "waves-ethereum-eth.org",
 "ethereum-eth.life",
 "mycrypto-com.com",


### PR DESCRIPTION
See link, https://urlscan.io/result/19210a3f-a33e-43fc-8900-da71aaee2c4b.