### PR TITLE
pay.ethconfirm.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,9 @@
 [
+"pay.ethconfirm.com",
+"ethconfirm.com",
+"eth-share.com",
+"eth-gift.com.paperplane.io",
+"iidexmarket.com",  
 "ebtweinfinance.com",
 "cardanoethereum.com",
 "ethergiveaway.website",


### PR DESCRIPTION
pay.ethconfirm.com
Trust-trading scam site
https://urlscan.io/result/98fd2339-f702-4ff2-a45e-5f1d3058d3cb/
address: 0x9BaaC782EA141718437a825704Fc61802993C03a

ethconfirm.com
Trust-trading scam site
https://urlscan.io/result/ac9d1c03-f780-41fb-811c-8b940b8f61da/
address: 0xb48c99C37b7cf4AC0A1c2dcA518782C1FEB4f066

eth-share.com
Trust-trading scam site
https://urlscan.io/result/52822950-ab88-40a1-abaf-74c09d24636c/
address: 0x024C344DA7208e60356378a252dAb771c34Be111

eth-gift.com.paperplane.io
Trust-trading scam site
https://urlscan.io/result/7badd11a-f68e-4146-82aa-0c82acf8a342/
address: 0x1CE4312fDd45c9184A5561314122B2244Bd862c9

iidexmarket.com
Fake Idex market stealing private keys
https://urlscan.io/result/3d468eca-a6d7-4c1b-85d3-0cf84dc05af0/