### PR TITLE
claimeth.epizy.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"claimeth.epizy.com",
 "walleteos.org",
 "nathanielpopper.promo-eths.com",
 "promo-eths.com",


### PR DESCRIPTION
claimeth.epizy.com
Trust-trading scam site
https://urlscan.io/result/aaede76a-084f-478b-92a9-2f668fc0ea27
https://urlscan.io/result/99843887-f183-42c0-ae4d-9aab94c5abc0
address:  0x40949225c4a1745a9946F6AAf763241c082cb9ac