### PR TITLE
eth-promo.net + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"eth-promo.net",
+"tdex.market",
+"login-myetherwallets.com",  
 "claimeth.epizy.com",
 "walleteos.org",
 "nathanielpopper.promo-eths.com",


### PR DESCRIPTION
eth-promo.net
Trust-trading scam site
https://urlscan.io/result/a5537a9e-d1e7-4a88-bff2-415b9637f59c/
address:  0x18BfF0b35d63B6e19775d3FBbB5a9fa9D7288A74

tdex.market
Fake Idex market
https://urlscan.io/result/20e663f0-3c64-496f-b282-34446cd47854/

login-myetherwallets.com
Fake MyEtherWallet
https://urlscan.io/result/55bb9bf4-5fe9-41f8-9332-f9ab7938cd34/

ethgive.online
Trust-trading scam site
https://urlscan.io/result/5b7cc296-e4fd-4a3c-b6bc-46254be94964/
address:  0xE03C6FDD69e268A00cC93Fa282Fb3ce82afC8B12