### PR TITLE
ethgift.org + hydroraindrop.typeform.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"ethgift.org",
+"hydroraindrop.typeform.com",
 "etherdelta.githiub.io",
 "githiub.io",
 "ether-promo.org",


### PR DESCRIPTION
ethgift.org
Trust-trading scam site
https://urlscan.io/result/d358cad2-c827-4fce-bcc9-86a4736b4a9a
address:  0xbCA804D30E8602F3ca47F8C8b3A44f8e03fe1594

hydroraindrop.typeform.com
Fake airdrop phishing for private keys
https://urlscan.io/result/d8c4a13b-c6f4-45bb-90cf-5dabfa918fb9