### PR TITLE
tron-block.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"tron-block.com",
+"idex-market.site",
+"ethgive.net",
 "eth4everyone.com",
 "mew-ehterwallat.com",
 "94.100.18.96",


### PR DESCRIPTION
tron-block.com
Fake TRON web wallet (cannot withdraw)
https://urlscan.io/result/14a0686a-1c27-44ab-ba4c-a6ea20b8d89f/
address: 0xdd1db171b110fb857311fde3236217894e7e9ab8

idex-market.site
Suspicious domain for idex.market
https://urlscan.io/result/d9ecc3e8-8795-4238-924f-5ec4504fd62a/

ethgive.net
Trust-trading scam site
https://urlscan.io/result/505224db-3818-4fe6-a8b9-532dc6dd160a/
address: 0x9fe0627303fe40f1631231B4DD016d30c13EafC7