### PR TITLE
ethpromo.org + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,9 @@
 [
+"eth-request.org",
+"eths.space",
+"btc-gift.org",
+"myethcrwallet-d.com",
+"eth-free.github.io",  
 "myerherwallet.tk",
 "myetherwallet.news",
 "myetherwalletz.org",


### PR DESCRIPTION
ethpromo.org
Trust trading scam site
https://urlscan.io/result/fa9a4c31-a050-4171-8dd7-fff5e68002fe/
address: 0x07cfB04588154b06E3958b5d70408244102014D5

eth-request.org
Trust trading scam site
https://urlscan.io/result/2fc3c732-b7fa-40c8-89c0-ef98ebfde3ac/
address: 0x718eE443Ffdf50b30a5e8226d4Ff71E605C5cA7C

eths.space
https://urlscan.io/result/2af94512-8176-46bf-9d6e-16cae27a8ed0/
Trust trading scam site
address: 0x096C39aB4fa36cA74A36FE1F4767FF487762f0Aa

btc-gift.org
Trust trading scam site
https://urlscan.io/result/f68afd05-e7a0-4374-a297-61125f285ef3/

myethcrwallet-d.com
Fake MyEtherWallet - iframing 94.100.18.96/my2/ - suspected address: 0x59032DAB819f2457bf01E52D02dd42073D2E7D13
https://urlscan.io/result/f688d3d5-f011-4ed8-839a-86ce1666700f/
https://urlscan.io/result/2fec81ab-d4ef-420d-b588-6d85200e3947/

eth-free.github.io
Trust trading scam site
https://urlscan.io/result/0836985c-9d82-415c-8335-6465335bb5bd/
https://urlscan.io/result/f7ee41ff-cdf1-4138-9ab0-b2a8e23b00da/
address: 0x1E89039e26c0b7f0E922011dbF3e16a230255cd8