### PR TITLE
tomochain.tech + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,8 @@
 [
+"tomochain.tech",
+"geteth.online",
+"get.etherofficial.com",
+"etherofficial.com",  
 "signupform1.typeform.com",
 "xn--ehterdeta-wd6d.com",
 "mycryiptowaliet.com",  


### PR DESCRIPTION
tomochain.tech
Fake Tomochain airdrop phishing for private keys
https://urlscan.io/result/e5fee213-90cc-4bd2-9a07-235c3e5e77ad/
https://urlscan.io/result/4e70356c-a0bd-46fb-8697-989bad358ed4/
https://urlscan.io/result/bd186b12-9184-4be9-bf58-349375ec2dce/

geteth.online
Trust trading scam site
https://urlscan.io/result/6a04769a-9384-402b-a104-da9f5f3d3588/
address: geteth.online 

xn--myethrwalet-vrb05c.com/signmsg.html
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/c6b29af2-8d46-4ac6-847b-da28df527b00/
https://urlscan.io/result/195435ed-8d32-4bb3-8987-15503793469b/


ethclaimer.byethost32.com/claim.php
Trust trading scam site
https://urlscan.io/result/703a4532-5e24-43cd-94b3-7b5c06927ced/

eth-give.info
Trust trading scam site
https://urlscan.io/result/ce72d631-70bf-40e4-851c-3cccc2465faf/

ethergiveme.com
Trust trading scam site
https://urlscan.io/result/a754fc40-4dc0-4cba-951b-d6404f3ca831/
address: 0x5a27a79f5217cad7d95cefcce0ecd18a4c33df84et

get.etherofficial.com
Trust trading scam site
https://urlscan.io/result/848a7d74-f387-4659-98bd-7d0bb9036b72/
address: 0xc3Cc3230d0C50DC3a3A8cf77F6d6fa0A618BF5D1

etherofficial.com
Trust trading scam site
https://urlscan.io/result/5f9bf66e-d310-48d7-95da-52f3cdb2a0d2/
address: 0xc3Cc3230d0C50DC3a3A8cf77F6d6fa0A618BF5D1


ethplatform.org
Trust trading scam site
https://urlscan.io/result/899dd71d-2acb-4e0b-9ae3-1e589d495086/
https://urlscan.io/result/8005bdd7-d771-45f6-8a73-4a7ac9b396f5/
address: 0x619B947996557DBB4b3ca878247e8514Fa3e7B30