### PR TITLE
ethofficial.info + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"ethofficial.info",
+"getsomeeth.com",
+"giveawaycrypto.org",  
 "idexmarket.io",
 "myetehrewallet.com",
 "lbex.market",


### PR DESCRIPTION
ethofficial.info
Trust trading scam site
https://urlscan.io/result/2528f876-0fd3-4e8a-b7ea-28ba969544c0/
address: 0xfB03e59c83b984DA0f6a5575B955541af28cCC65

getsomeeth.com
Trust trading scam site
https://urlscan.io/result/27470387-5834-4428-8ae0-7b5feadea1fb/
address: 0xdb850d7dC1aDe8eC00CE4269e732d3Aa44286f73

giveawaycrypto.org
Trust trading scam site
https://urlscan.io/result/ff03cb73-050c-4b93-81f6-6b03d49b80c8/
address: 0xeaA4b711e7C025899460b429BeF1ff8155ba4C66