### PR TITLE
ethpromo.cc + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"ethpromo.cc",
+"idex-market.eu",
+"idex-login.net",  
 "eos-swap.com",
 "keyfund.io",
 "ethereum-promo.xf.cz",


### PR DESCRIPTION
ethpromo.cc
Trust trading scam site
https://urlscan.io/result/77f317d7-44a8-4774-affc-f1303fc1a409/
address:  0x05e85D73Eaf6fEF228294fdF867aBBa98552A99F

idex-market.eu
Fake idex phishing for keys
https://urlscan.io/result/4fbd0c72-4bca-47eb-890a-8197a14a1a42/

idex-login.net
Fake idex phishing for keys
https://urlscan.io/result/7b3fe2c9-cefe-4463-886c-d4dd3cdd0623/