### PR TITLE
electrocoin.typeform.com + myetherwalllet.trade

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"electrocoin.typeform.com",
+"myetherwalllet.trade",  
 "btcoin.vu",
 "btc-giveaway.com",
 "btcofficial.info",  


### PR DESCRIPTION
electrocoin.typeform.com
Fake airdrop directing users to a fake MyEtherWallet - myetherwalllet.trade
https://urlscan.io/result/7a5852b5-b5a2-4938-b027-4488e56b8a78/

myetherwalllet.trade
Fake MyEtherWallet
https://urlscan.io/result/46901a9f-7bb0-4774-bee5-9c43080363aa/