### PR TITLE
etherskan.io + etherscan.ltd

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"etherskan.io",
+"etherscan.ltd",  
 "myiteher.com",
 "musk-giveaway.com",
 "get-ether.cash",


### PR DESCRIPTION
etherskan.io
Fake Etherscan
https://urlscan.io/result/86dbc2d5-6741-45a6-8a8c-40d0d792340f/

etherscan.ltd
Trust trading scam site
https://urlscan.io/result/9c0021c2-2bb9-4d0b-8c52-901984e43841/
address:  0x5c0133DC7E8811B3FADdD1016d0800Dbf5beC2D8