### PR TITLE
ethereum.website.tk + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"ethereum.website.tk",
+"ethereum-bonus.com",
+"blttrex.us",  
 "myetherwallat.co",
 "xn--mythrwalet-umbv35c.com",
 "helbiz-token.trade",


### PR DESCRIPTION
ethereum.website.tk
Trust trading scam site
https://urlscan.io/result/5b2b4fa8-e28e-4ec7-bc2b-6fcdef12551b
address: 0x0E2fA227599b1701cEEEcfBF0c92d8D23b2F493e

ethereum-bonus.com
Trust trading scam site
https://urlscan.io/result/bc0f3c67-c250-4fe1-8763-3e699d199f19/
address: 0x916d37534f95f30c35A60a58150F48c2D0fF4Be2

blttrex.us
Trust trading scam site
https://urlscan.io/result/036952c2-98a8-4388-924e-ee0e50d54ee8/
address: 0x92d43D2f55E077D1beBC6e348a9F4FF64fD4F21A