### PR TITLE
get.ethpublic.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"get.ethpublic.com",
+"ethpublic.com",
+"ethereum-get.org",  
 "ethereum.website.tk",
 "ethereum-bonus.com",
 "blttrex.us",  


### PR DESCRIPTION
get.ethpublic.com
Trust trading scam site
https://urlscan.io/result/5e9a29e9-648b-43db-b2f6-510ef6a1f0d7
address: 0xe4fc4C3889B5442391acAD627673F4Ef7Efe7B97

ethpublic.com
Trust trading scam site
https://urlscan.io/result/4177f5a4-4828-442b-9462-2e5c773cb873
address: 0xe349B26753ECa84A2858901d414c612c8c8e20f9

ethereum-get.org
Trust trading scam site
https://urlscan.io/result/2dae7ce1-aa28-432e-b625-6e5253d3ac3e/
address: 0xaBbD5F7D4DE3c91706c73FD7d09b9ec3Ed9cA697