### PR TITLE
cryptoaway.org + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,8 @@
 [
+"cryptoaway.org",
+"ethdeals.org",
+"ethgiveaway.io",
+"claimeth.me",
 "xn--myetherwalett-4hc.net",
 "ethereumgiveaway.typeform.com",
 "zecblock.info",


### PR DESCRIPTION
cryptoaway.org
Trust trading scam site
https://urlscan.io/result/c587e886-8192-41f2-b632-cb5cb2254ce0/
address: 0xbEC9410b01671bB6521996B141BB95Ebff87Cb31

ethdeals.org
Trust trading scam site
https://urlscan.io/result/e5e8f7b5-1aff-4228-8e31-4aa9205b7bee/
address: 0x0E42f55Da7ADe5673130e23232CEC6094d34087c

ethgiveaway.io
Trust trading scam site
https://urlscan.io/result/75d1d363-0132-4618-8a75-14b29b6dae6a/
address: 0x06091b32533835265Bfa6EF8B32B04747Ba77bB2

claimeth.me
Trust trading scam site
https://urlscan.io/result/d4823a7c-6932-4417-873b-0df5657611f7/
address: 0xf2Db2f7AEC4E32Fe10A8352e1E02D099a194f7A7