### PR TITLE
xn--myethrwalett-8vb19c.net

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"xn--myethrwalett-8vb19c.net",
 "free-ethereum.us",
 "tron-mainnet.network",
 "receive-crypto.com",


### PR DESCRIPTION
xn--myethrwalett-8vb19c.net
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/870b6b80-baa5-4d0c-b9c1-44bc75d38f2d/
https://urlscan.io/result/134f33a4-1fb7-4e02-9468-73e380d97588/

Fixes https://github.com/409H/EtherAddressLookup/issues/667