### PR TITLE
myethertrust.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"myethertrust.com",
 "academiconswap.typeform.com",
 "zillowblockchain.org",
 "myetherwallet.signmsg.online",


### PR DESCRIPTION
ether-give.club
Trust trading scam site
https://urlscan.io/result/cd5adf1f-97b0-4371-9399-58a202875ebd
address: 0x50a9a8c8ce2bb0ea10f4d4a586ac2d77257b8247

myethertrust.com
Fake MyEtherWallet
https://urlscan.io/result/7a407d1b-72b4-41f3-8a77-9931faced750/
https://urlscan.io/result/95cff247-e7a5-4257-be42-31cefbf91906/