### PR TITLE
xn--myetherrwalet-5hc.net + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"xn--myetherrwalet-5hc.net",
+"idice.epizy.com",
+"bahs.edu.tt",  
 "gese.network",
 "etheroll.io",  
 "myethertrust.com",


### PR DESCRIPTION
xn--myetherrwalet-5hc.net
Fake MyEtherWallet - IDN homograph attack domain. Suspected address: 0x7e25f33c1e3402f2197dab251ce2d73cdbcb77a3
https://urlscan.io/result/451f46eb-10d1-4f73-a3db-accbd07bd231/
https://urlscan.io/result/1a5b2a0e-bc4c-494e-8d9b-a0c70660e94f/

idice.epizy.com
Fake idice GUI
https://urlscan.io/result/afb9685c-b12e-428b-a7c3-fc6c9a32405b
address: 0x9b2D66562bea3EefEc436dF0Fee88Dd89CbE547b

gene.network
Fake crowdsale site directing users to a fake MyEtherWallet http://bahs.edu.tt/https_myetherwallet.com:gese_token_redeem/
https://urlscan.io/result/400cf5f4-43bb-4671-bdba-5508c4113596

bahs.edu.tt
Hosting a fake MyEtherWallet
https://urlscan.io/result/02b1388f-408b-4f7a-811f-dbf5f9f797fa/
https://urlscan.io/result/dc97ff76-e8b7-47db-89bc-91d5335cccc2/