### PR TITLE
ethpubs.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,9 @@
 [
+"ethpubs.com",
+"binancegiveaway.org",
+"ethgws.org",
+"ethereumreturns.com",
+"takeeth.org",  
 "idex-market.at",
 "wallet-idex.net",  
 "bittrex-id.com",


### PR DESCRIPTION
ethpubs.com
Trust trading scam site
https://urlscan.io/result/0312e541-0319-4733-b6c1-26c51a3f5904/
address: 0x52Bdb97E587a35d5e54b01344168D41783120310

binancegiveaway.org
Trust trading scam site
https://urlscan.io/result/7dc36378-3e1e-449e-9434-96e82306014a
address: 0x1aBC65765FD0DF7D997635EBE3027384BCF7923E

ethgws.org
Trust trading scam site
https://urlscan.io/result/c99c3418-d284-4a8c-80ca-a16ddca723dc/
address: 0x28A6D6E41fcCA5b003f22ceBa48Aa689325Dd62B

ethereumreturns.com
Trust trading scam site
https://urlscan.io/result/8067b857-b169-4ca4-adc9-ff3c3c529a40/
address: 0x2E6Ace64e85572eeDAaD739c3172EcE853153C73

takeeth.org
Trust trading scam site
https://urlscan.io/result/1b84c11d-656f-44cf-bde1-9934b4b081a0/
address: 0x28A6D6E41fcCA5b003f22ceBa48Aa689325Dd62B