### PR TITLE
ethergive.net

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"ethergive.net",  
 "idix-market.info",
 "icon-block.org",  
 "masterthecrypto.org",


### PR DESCRIPTION
ethergive.net
Trust trading scam site
https://urlscan.io/result/066db09b-331c-4d23-935e-1e2189ef30c3
address: 0x2E3Fd2B400a269f7a0B1AaF448EF02679cd557e9