### PR TITLE
airtake.info

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"airtake.info",
 "ethergive.net",  
 "idix-market.info",
 "icon-block.org",  


### PR DESCRIPTION
airtake.info
Trust trading scam site
https://urlscan.io/result/2c0e8447-0ac3-41aa-8638-4736cc48244f
address: 0xB9556A1cb3150148443e9e9E9C29491FF48640Ee