### PR TITLE
binance-giveaway.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"binance-giveaway.com",  
 "walleteos.io",
 "originprotocol.typeform.com",
 "myefhervvallet.com",


### PR DESCRIPTION
binance-giveaway.com
Trust trading scam site
https://urlscan.io/result/79b97afe-c7e8-4712-9962-e5a12d7bf561/
address:  0x15B4E32d5026A5A9Ad3b68BEcAdceB00B4eB9729