### PR TITLE
today-ethereum.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"today-ethereum.com",
+"ethnow.org",  
 "eoscountdown.co",
 "xn--mythrwalet-smb0a05c.com",
 "go.boosteth.com",


### PR DESCRIPTION
today-ethereum.com
Trust trading scam site
https://urlscan.io/result/0deae08e-688c-414a-97e6-e3fe675b5344
address: 0x4dD0eF53784030fA675e2677F9CdC2a3e32E956B

ethnow.org
Trust trading scam site
https://urlscan.io/result/045a6b1d-6808-4347-8227-99ce3686cdbd
address: 0x3963C374e0E71018dBA76814c13fdd5458d55898