### PR TITLE
giveawaypromo.byethost14.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"myetherwalllet.online",
+"odyssey.plus",  
 "epromo.cc",
 "ethereumgw.org",  
 "index-marketz.com",


### PR DESCRIPTION
giveawaypromo.byethost14.com
Trust trading scam site
https://urlscan.io/result/0937b2ec-aa70-4a5d-8ce1-bf8f608c3a5d
https://urlscan.io/result/33778c52-874b-4fd4-8278-456674e4f415
address: 0x8D3CFe26a635A322F814512d3e09dF75F7CbfBd3

myetherwalllet.online
Fake MyEtherWallet
https://urlscan.io/result/d283b3cf-8d78-4cfb-a652-6d6f7003bc33/

odyssey.plus
Fake Airdrop phishing for private keys
https://urlscan.io/result/81c5f681-3e76-48fe-86ac-e6dd27be6d48/
https://urlscan.io/result/905d3f38-c720-4755-9ed5-0cfee96c8ac7/
https://urlscan.io/result/c8fd8cd5-2e13-4840-aa92-acaa9f8404dd/
address: 0xaf8185ffff6a3508fc5498a5165bf64de0b0a1e5