### PR TITLE
ethereum-prize.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,12 @@
 [
+"ethereum-prize.com",
+"sharekit.io",
+"etherbonus.live",
+"sparkster.site",
+"idex-exchange.market",
+"idex-narket.com",
+"idexmarket-inc.com",
+"idexmarket-incs.com",  
 "fantom-foundation.tech",
 "indexmarkett-corp.com",
 "giveth.ws",


### PR DESCRIPTION
ethereum-prize.com
Trust trading scam site
https://urlscan.io/result/5c6c1e2e-ea9c-46e0-8255-071b2605b300/
address: 0xc46E1430B1D4B7066B9B6655293492256BA216B9

sharekit.io
Trust trading scam site
https://urlscan.io/result/b81e805c-bcf2-4d16-8b22-c8cdaf8a09a6/
address: 0x89271335DB9d0024F725Ab23415678CdEA3EB368

etherbonus.live
Trust trading scam site
https://urlscan.io/result/eb174f8c-46c4-4184-bfb2-18a2410ca29d
address: 0x5188d13bdd9D7Ac30324a569E2cE42488374738e

fantom-foundation.tech
Fake Fantom crowdsale site
https://urlscan.io/result/21e94e99-d334-4e41-aea6-2dacd8deab4f
address: 0x567211d48BCFc706EDbAf5103196425cDf54289F

sparkster.site
Fake Sparkster crowdsale site
https://urlscan.io/result/9b6c3c08-d7d6-4061-a6d5-3d55b2ca0dbd/
https://urlscan.io/result/4148da2b-b360-4de5-8739-649fb6e1e79f/
address: 0xCc8DE4cCF031ae0a86db0c561E790173E35D3De7

idex-exchange.market
Suspicious Idex market domain (no dns right now)
https://urlscan.io/result/4352e2c5-9572-48e3-89d3-6798e7651f45/

idex-narket.com
Suspicious Idex market domain
https://urlscan.io/result/5983445a-5cf8-4894-849a-8c8fc4e4c547/

idexmarket-inc.com
Fake IDEX market phishing for keys
https://urlscan.io/result/e8ae62cc-3c90-412b-b1b8-bbefa2935071/

idexmarket-incs.com
Fake IDEX market phishing for keys
https://urlscan.io/result/11784b9a-9b34-4e1d-b51b-f6d5726480b8/