### PR TITLE
get.perfecteth.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,8 @@
 [
+"get.perfecteth.com",
+"perfecteth.com",
+"newsair.org",
+"top-ethereum.com",  
 "elon-shares.com",  
 "s-msg-myetherwallet.com",
 "myetherwallett.net",


### PR DESCRIPTION
get.perfecteth.com
Trust trading scam site
https://urlscan.io/result/4aea6e9f-3c80-4230-8da9-2b6225a6351a/
address: 0x6997726E03707Bf08032B8b6Da935cae80524bCA

perfecteth.com
Trust trading scam site
https://urlscan.io/result/a67d8d88-a5c1-4850-97f1-ccc58e0fd681/
address: 0x6997726E03707Bf08032B8b6Da935cae80524bCA

newsair.org
Trust trading scam site
https://urlscan.io/result/db00b2f1-fc35-4da9-8ae3-407eed4964ac/
address: 0xF1a4b668D15F0E66543e9F1F795cC2B0f97E3ef2

top-ethereum.com
Trust trading scam site
https://urlscan.io/result/dc12715e-257d-469f-9c4f-e68cb57a4e27/
address: 0x83D7Cb758C30d067e99E9f52F9e4f987101aB888