### PR TITLE
added xn--fent-ipa.re to whitelist

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -1,4 +1,5 @@
 [
+"xn--fent-ipa.re",
 "xn--1-ylb.net",
 "github.com",  
 "codercoin.io",


### PR DESCRIPTION
Adds fenêt.re to the whitelist.

Fixes: #725