### PR TITLE
xn--eosauthorty-wcb.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"xn--eosauthorty-wcb.com",
+"etherfree.info",
+"free-ethers.org",  
 "eth-claim.net",
 "ethfreegift.org",
 "myenterworlld.com",


### PR DESCRIPTION
xn--eosauthorty-wcb.com
Fake EOSAuthority phishing for keys (POST /store.php)
https://urlscan.io/result/b899a6d2-b8e6-4f78-8592-34fbad046aa8/

btc.etherfree.info
Trust trading scam site. Bitcoin address: 18b7PTLaa2TPtn5V5moBwSsWTEm6Ny2n8Y
https://urlscan.io/result/bf88caa6-d8a7-4f1e-aedd-9d92ed30d8a8/

etherfree.info
Trust trading scam site
https://urlscan.io/result/e6dbae7f-adf7-4c65-8c3d-0f600edb6210/
address: 0xba8A5cF96D605B630025E3e2C8bd177391e32122

free-ethers.org
Trust trading scam site
https://urlscan.io/result/332578a1-1a5c-45f3-b8b4-10154f79e383/
address: 0x4c6cdD82bF2B0627350bB660C2a18B2Db8880Ce1