### PR TITLE
ethaway.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,11 @@
 [
+"eth.tronbonus.network",
+"tronbonus.network",
+"ethaway.com",
+"eth-gift.net",
+"eosdark.com",
+"xn--mytherwaet-y7a46ha.com",
+"freepromoeth.com",  
 "idex-sitecorp.com",
 "myethwallofficiall.com",
 "myetherwallet-logiin.com",


### PR DESCRIPTION
ethaway.com
Trust trading scam site (promoted via bit.ly/2Iw0Kae+)
https://urlscan.io/result/038a3df4-dfe1-4981-bf8e-887843c96b70
address: 0x1c40D1a1cAc7C586b9509C565296F91c8441aF9f

eth.tronbonus.network
Trust trading scam site
https://urlscan.io/result/39c13514-f4ea-45a6-ae8d-0eda4284f89f/
address: 0x0f89B38968065A571eeaf34dD6BF2093fb55c20F

eth-gift.net
Trust trading scam site
https://urlscan.io/result/7b85d749-3b52-4bc1-89a5-56d5fb567769/
address: 0x73c9B03B1DaDeA685f34b17DdAFBC11BD6327B6D

eosdark.com
Fake airdrop directing users to a fake MyEtherWallet xn--mytherwaet-y7a46ha.com
https://urlscan.io/result/31015722-adc4-4edb-aeaf-ec9a83f30b5a/
https://urlscan.io/result/f5bf5d08-cd14-43b2-8ac6-55e1d2da9d3b/

xn--mytherwaet-y7a46ha.com
Fake MyEtherWallet domain - IDN homograph attack domain
https://urlscan.io/result/569fad5b-3a14-42a5-8993-cf72a08b1f55/

freepromoeth.com
Trust trading scam site
https://urlscan.io/result/18f244b6-cd8a-47f8-80ed-1a51277f6a3a/
address: 0x9e9e3b124370C763d1a4e838069Da3dfDbfcA059

----

get-bitcoins-now.com
Trust trading scam site
https://urlscan.io/result/51e04e38-e844-42d2-abaf-b82dac43689e/
address: 0x9Da01DF0eeAE50B30845a1cAFb27E1f75887B887

ethe.mediumblog.top
Trust trading scam site
https://urlscan.io/result/a9e07153-703d-4c75-85a2-1b8f949401cf/
https://urlscan.io/result/59d0e269-99a0-4d8d-82e2-fe1d3224218e/
address: 0x5208d7f63A089906889A5A9CAed81E9C889E64F8

ethgift.net
Trust trading scam site
https://urlscan.io/result/f90c7a7d-e69c-4254-8fcc-dd323c4ad8b2/
address: 0xBBFaF27674C2eB5D13eDC58A40081248D13DcFeb

5000eth.io
Trust trading scam site
https://urlscan.io/result/f5edd38d-a9a4-44ae-9739-6188873d3895/
address: 0x0e783FdCFd5F3f1AfbB11062315456BD16feE122

promo-etherum.com
Trust trading scam site
https://urlscan.io/result/7c69185e-c729-48b0-b9c7-b0f95d804670/
https://urlscan.io/result/de8ea06a-86bb-471d-820e-e84496d91b3b/
address: 0x9b2D66562bea3EefEc436dF0Fee88Dd89CbE547b