### PR TITLE
eosauthorithy.com + ethereumanniversary.org

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"eosauthorithy.com",
+"ethereumanniversary.org",
 "xn--eosauthorty-jzb.com",
 "xn--eosuthority-m7a.com",
 "xn--eosauthorty-kcb.com",  


### PR DESCRIPTION
eosauthorithy.com
Fake EOS domain - phishing for private keys with POST /store.php
https://urlscan.io/result/e09358b9-6ae8-4a67-aaf2-14ddc2fd6561

ethereumanniversary.org
Trust trading scam site
https://urlscan.io/result/5780b378-df75-49c5-8459-c6d178a5a4bd
address:  0xaec2Cc8986BB14C0C604d5Adf725BA33920102bc