### PR TITLE
Remaining SCAMs at 104.152.168.18

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,11 @@
 [
+"xn--ethrdelta-iib.com",
+"ethergiveaway.site",
+"eosclassic.network",
+"eosauthority-kyc.com",
+"eoscountdown.network",
+"petraforbinance.com",
+"idex.market.xn--con-vta.site",
 "trx.claims",
 "ethbig.net",
 "vechain-platform.org",


### PR DESCRIPTION
xn--ethrdelta-iib.com https://urlscan.io/result/d11dcf82-ca26-4962-a742-2097e4d9cd2e
ethergiveaway.site https://urlscan.io/result/3d1107af-104c-40b4-bac6-cccafabe213e
0xf3Bc09E9c493F7d446df129168894ff521175326
0x408FaC2d2d3D3AC4E356aA188119F5624FD8C9f6
eosclassic.network https://urlscan.io/result/818abc2c-80aa-45f9-9537-656e7c70aa24
eosauthority-kyc.com https://urlscan.io/result/333c178c-9c32-4af9-bd59-fad4930b1649
eoscountdown.network https://urlscan.io/result/a0d8d9ec-ee9d-4ca8-bd94-b98f6c57931d
petraforbinance.com https://urlscan.io/result/1d180863-da39-4874-a539-c7a88841a960
idex.market.xn--con-vta.site https://urlscan.io/result/1982018f-3ee6-46d7-8e20-cf251ad3294d