### PR TITLE
ethereumfoundationgift.tumblr.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,11 @@
 [
+"ethereumfoundationgift.tumblr.com",
+"btcpramengyve.com",
+"claim-btc.org",
+"btcbig.org",
+"btcbonus.win",
+"btcpromogiveback.com",
+"btcpromoget.com",  
 "bit-airdrop.com",
 "giveaway.claimeth.net",
 "claimeth.net",


### PR DESCRIPTION
ethereumfoundationgift.tumblr.com
Trust trading scam site linking to ethe.mediumblog.top/payment.php
https://urlscan.io/result/1e011872-7c62-460b-8266-a633ff065b7e/
address: 0x5208d7f63A089906889A5A9CAed81E9C889E64F8

btcpramengyve.com
Trust trading scam site. Bitcoin address: 34oxKKuq8g7W23gvDD6K3bpbTVCg1FLYGb
https://urlscan.io/result/14575086-86a1-4002-930b-84817f383e62/

claim-btc.org
Trust trading scam site. Bitcoin address: 1FVwwp98FBKJV8MzSFNN38afSHqiYrxXjs
https://urlscan.io/result/a4d0b7b8-53cc-4bba-ac8d-0cdc442ac4e4/

btcbig.org
Trust trading scam site. Bitcoin address: 15HM6dXaUvDdXri3rz44wKv13No57h4TN
https://urlscan.io/result/17b2ab1e-bffb-4728-a591-358459a23f9b/

btcbonus.win
Trust trading scam site. Bitcoin address: 1Co5gnEn1wBTyigfH9udnuUgha27pdETS9
https://urlscan.io/result/8f2554da-d371-4111-9a57-d6171090b022/

btcpromogiveback.com
Trust trading scam site. Bitcoin address: 3LfmhNmuE3vXuruFG9nHwT9heMYvceahhQ
https://urlscan.io/result/aafebcf7-4fe5-425d-99d7-e20d1eef024e/

btcpromoget.com
Trust trading scam site. Bitcoin address: 34oxKKuq8g7W23gvDD6K3bpbTVCg1FLYGb
https://urlscan.io/result/39e1b71d-f756-4a2c-9f0b-54365690de3c/