### PR TITLE
ethpromofree.com + sparkster.com.de

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"ethpromofree.com",
+"sparkster.com.de",  
 "buterineth.org",
 "ethereum-promo.website",
 "myertnerwalletr.com",


### PR DESCRIPTION
ethpromofree.com
Trust trading scam site
https://urlscan.io/result/dd9666df-e862-4760-9c98-cbe6e9dc0746/
address: 0x0E50faC3B2eaEe7BA87B6d644B6c03E946B19f8d

sparkster.com.de
Fake Sparkster crowdsale site
https://urlscan.io/result/b516e3f9-1756-4905-8b6a-bbe0c9bb2de1/
https://urlscan.io/result/132957ea-6cab-4778-84ad-45fdf85adfb6/
address: 0xd0aCAc843AAAb4Cef20b322405405E67e90147d1