### PR TITLE
xn--bnanc-r51bze.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,11 @@
 [
+"xn--bnanc-r51bze.com",
+"ycbit.net",
+"kuccin.com",
+"lnitbtc.com",
+"www-nycryqto.com",
+"www-nycryptos.com",
+"ethers.pw",  
 "airdropbox.site",
 "ethereum-giveaway.top",
 "etherescan.net",


### PR DESCRIPTION
xn--bnanc-r51bze.com
Fake Binance - IDN homograph attack domain
https://urlscan.io/result/23f13b42-7281-4502-a330-19b2362cafce/

ycbit.net
Suspcious Yobit phishing for logins (not deployed yet)
https://urlscan.io/result/336676b4-d765-4f4a-aa6e-5e75686ba7b3/

kuccin.com
Suspcious Kucoin (not deployed yet)
https://urlscan.io/result/142167bc-a626-435e-9e43-9586f508b67e/

lnitbtc.com
Suspcious Hitbtc (not deployed yet)
https://urlscan.io/result/0242fd36-fc10-45e6-8ed6-26700ce07481/

www-nycryqto.com
Suspicious mycrypto domain
https://urlscan.io/result/a86bc4cb-06a6-4282-bbc7-69ae43518834/

www-nycryptos.com
Suspicious mycrypto domain
https://urlscan.io/result/e99a5f5f-c13e-4d79-b4c2-fd2a25fbd571/

go.ethers.pw
Trust trading scam site
https://urlscan.io/result/2bc5066e-7bfa-4942-8c56-6dd9a533a29c/
address: 0xE5f08B41BC8e37EE5E5934d4A27e67e059370011