### PR TITLE
xn--omiseg-ul8b.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"xn--omiseg-ul8b.com",
+"xn--myethrwalle-6qb4278g.com",
+"myehterwelliet.com",  
 "ethcoin.store",
 "kralkem.com",
 "blockchalim.info",


### PR DESCRIPTION
xn--omiseg-ul8b.com
Fake OmiseGo publication linking to a fake MyEtherWallet xn--myethrwalle-6qb4278g.com/#contracts
https://urlscan.io/result/2b86d579-3cac-44dd-8147-e52e9e863e8d
https://urlscan.io/result/4c6e80a7-ffce-4dc7-b707-9104669936fd

xn--myethrwalle-6qb4278g.com
Fake MyEtherWallet - IDN homograph attack - phishing for keys
https://urlscan.io/result/c3d99bd1-d309-4c42-a68a-d0fe0bf449d8

myethervvallet.net
Suspicious MyEtherWallet domain
https://urlscan.io/result/2d8b4d34-10da-4381-9cd0-6bb6617dcf9b/

myehterwelliet.com
Fake MyEtherWallet phishing for keys
https://urlscan.io/result/381b05a5-97c5-4545-9fd6-236bb65876a1/