### PR TITLE
bittrex-sigin.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"bittrex-sigin.com",  
 "safe.justgeteth.com",
 "promotion-eth.net",
 "eth-airdrop.info",


### PR DESCRIPTION
bittrex-sigin.com
Fake Bittrex phishing for logins with POST /verification.php
https://urlscan.io/result/9875a705-35da-420a-bc8a-0c643d0db6dc/


---

giveaway.ether-claim.org
Trust trading scam site
https://urlscan.io/result/4d447289-a35d-43cf-a885-b4a0a44eee71/
address: 0xe1228F81C01b80EfeFAC957483d63a40c6d635e1