### PR TITLE
musk-air.org + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,8 @@
 [
+"musk-air.org",
+"safe-claims.info",
+"bitstamp.pw",
+"binance-web.com",  
 "ethereum-gift.info",
 "eth-club.club",
 "ethgiving.000webhostapp.com",


### PR DESCRIPTION
musk-air.org
Trust trading scam site
https://urlscan.io/result/2dd66c5f-1860-440f-a21c-ea6b6869975d/
address: 0x72696cE345abB71398384e42CfbF6C9A995246c0

safe-claims.info
Trust trading scam site. Linking users to giveawaypromo.byethost14.com
https://urlscan.io/result/eb1d9dd5-6af9-452e-9eda-66278a02eddf/
address: 0x6a9c2ec4f4888d7338fc1b28584aaafeb01e6db3

bitstamp.pw
Fake Bitstamp exchange phishing for logins with POST /_indexSend.php
https://urlscan.io/result/eb5baf6a-4170-4502-986d-1dd07bc6abf5/
https://urlscan.io/result/5e607e6b-d132-4aec-b78b-d1789cefdc42

binance-web.com
Fake Binance exchange phishing for logins with POST /_loginSend.php
https://urlscan.io/result/61e8fd01-eaa0-45d0-a9a3-98cd6160ec25/
https://urlscan.io/result/b259851a-d380-4d5d-8ea3-6b128776ad03/