### PR TITLE
eth-claim.pw + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"eth-claim.pw",
+"xn--tronscn-mwa.com",
+"tron-scan.info",  
 "ethereum-foundation.info",
 "bigcryptogift.info",
 "claim-binance.com",


### PR DESCRIPTION
eth-claim.pw
Trust trading scam site
https://urlscan.io/result/73a07fe4-9426-4b11-942b-7c08b36ca480
address: 0x4D1DCFbF1299EB1007d55976754bb41a87eb9D0F

xn--tronscn-mwa.com
Fake Tronscan phishing for keys with POST /auth.php
https://urlscan.io/result/a1eb8d1b-d9ac-42ed-9a6b-e51c61dec208/

tron-scan.info
Fake Tronscan phishing for keys (redirecting to xn--tronscn-mwa.com)
https://urlscan.io/result/fa7e0bf6-18c5-4b40-89fa-aa76f9460e41/