### PR TITLE
elonmusk.ltd + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"elonmusk.ltd",
+"elonmusk.fund",
+"loginbinance-com.umbler.net",  
 "selleth.io",  
 "blokclnain.com",
 "giftreturn.mysteria.cz",


### PR DESCRIPTION
elonmusk.ltd
Trust trading scam site. Linking users to elonmusk.fund/e/
https://urlscan.io/result/da9eb451-dc85-4095-b32c-dcc92e93d5d8/
address: 0x08afea4eC3659A2e478F81fef2B784176a0B7D2F

elonmusk.fund
Trust trading scam site
https://urlscan.io/result/512de643-7033-413a-9985-bbd770559748/
address: 0x08afea4eC3659A2e478F81fef2B784176a0B7D2F

loginbinance-com.umbler.net
Fake binance phishing for logins with POST /processar_1.php
https://urlscan.io/result/0949343d-1f7b-4546-a3a1-8f598223d03e/