### PR TITLE
elctrurn.org + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"elctrurn.org",
+"jaxx.one",
+"lkraken.xbtxv.com",  
 "musk-prize.info",
 "medium-io.site",
 "claim.safepaycoins.com",


### PR DESCRIPTION
elctrurn.org
Fake Electrum site with potentially malicious downloads: https://www.virustotal.com/#/url/cc732ec6eb0b8450ae616bed50fb14c5ca95e5859dba97367a00e3a5e9a541c4/detection
https://urlscan.io/result/f13a47ff-ba95-4ab4-a983-17742dcf797d/

jaxx.one
Fake Jaxx web wallet
https://urlscan.io/result/9e423c2c-5086-4af3-82bd-0107b47e710c/