### PR TITLE
firstcrypt.info

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"firstcrypt.info",
+"earn-crypto.info",  
 "binance.com6537261.ml",
 "binance.com762381.cf",
 "com762381.cf",


### PR DESCRIPTION
firstcrypt.info
Fake exchange (clone of firecrypto.info). Bitcoin address: 1PTAaVk6onxkgU1ZXxMfcPG9txgQ6rYVef
https://urlscan.io/result/175caa23-598d-44e5-923c-ad2e338c1705/
https://urlscan.io/result/d40ba48e-6594-4925-b04b-bf06832c6bb9/
address: 0x1E711A766cD4EC07C590EeF54A112190B4826b4e