### PR TITLE
line-crypto.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"line-crypto.com",
+"etherdelta.icu",
+"xtrony.blogspot.com",  
 "poloniex.com135i478847258477.ml",
 "com135i478847258477.ml",
 "mnyicthervvalliet.com",


### PR DESCRIPTION
line-crypto.com
Scam exchange
https://urlscan.io/result/9698ca7d-b6a1-48a5-ae3e-91177f8e2ccd
address: 0x1E711A766cD4EC07C590EeF54A112190B4826b4e

etherdelta.icu
Fake EtherDelta phishing for keys with POST /api.php
https://urlscan.io/result/c288eecd-d902-4ae4-8ff8-fe058644439b/

xtrony.blogspot.com
Trust trading scam site. Tron address: address:TPcDNYz4AxCaLCY2Xx4i95jGYwCjUrxg5r
https://urlscan.io/result/96886f2c-6d2b-4bb1-9e21-e53cb460f0e2/