### PR TITLE
doublecoinio.jdevcloud.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,7 @@
 [
+"doublecoinio.jdevcloud.com",
+"mediium.org",
+"myetherwallet-be.space",  
 "coinbase.pro-xca.com",
 "pro-xca.com",
 "awx-ly.store",  


### PR DESCRIPTION
doublecoinio.jdevcloud.com
Coin doubling scam (and email and public address harvester)
https://urlscan.io/result/ac9e3c36-61aa-4dbc-92be-0a865636c685/
https://urlscan.io/result/847fc504-9e56-4f35-acf3-0814da0b6a4a/
https://urlscan.io/result/4d428125-a99c-4498-9eeb-163e6df33dff/

mediium.org
Trust trading scam site
https://urlscan.io/result/104d81ee-3a14-41d4-a702-9f1b899956b8/
https://urlscan.io/result/7971b8d8-ab99-4431-b0a5-273997b36d45/
address: TX9oqhThyQdGXrDMacRXAvsWPoxQspQLFw

myetherwallet-be.space 
Fake MyEtherWallet phishing for keys with POST /app/keys.php
https://urlscan.io/result/be43a3a8-91f2-48ba-8ed4-090678989795/
https://urlscan.io/result/02ec175c-88be-42b4-870c-2336b6d5c18c/

----

spacex.gives
Trust trading scam site
https://urlscan.io/result/df03f2ac-2fbc-4b5c-8544-049a6a5bac79/
https://urlscan.io/result/ad2ff5fa-243b-45d2-bd9d-e8e333b0269d/
https://urlscan.io/result/eb0fccf1-6c33-48c9-9a43-e46091d033df/
address: 0x9969dE6D6CF15fF37Ad56116fCc89efc4a04EDfF
address: 17jT3gCE7AksjNJh2VRoxZ57DcZ5KiQGQ6