### PR TITLE
btcholiday.net  + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,10 @@
 [
+"btcholiday.net",
+"vitalik.cf",
+"ether-give.org",
+"binancedrop.com",
+"idexx-market.pw",
+"bittrex-global-site.com",  
 "gemini-airdrop.netlify.com",
 "myetherewallet.io",
 "giveaway-crypto.tech",


### PR DESCRIPTION
btcholiday.net 
Trust trading scam site	
https://urlscan.io/result/c28ab2fe-3a83-4f44-8d25-dd3563bf750a/

vitalik.cf 
Trust trading scam site
https://urlscan.io/result/590b0d96-4789-417f-b6fb-5646e5300dc4/
address: 0x738a8589924B5C924997DDFB23238064eD238920 

ether-give.org
Trust trading scam site
https://urlscan.io/result/2a0c5b92-bc53-4ced-b5cc-88be7d873cad/
address: 0xf9c87DCf56598cE676FDdA2FEbfDB3Eb45e5007E

idexx-market.pw 
Fake Idex phishing for secrets with POST /log.php
https://urlscan.io/result/e7bf7e80-a405-40cd-a069-f15fad4df68b/
https://urlscan.io/result/0ccf0064-8f54-41e4-aa69-4017af1ad38d/

bittrex-global-site.com
Fake Bittrex phishing for logins
https://urlscan.io/result/be02ee81-3452-4b19-b1aa-7a452085ff60/
https://urlscan.io/result/f0079ab5-40e0-4e95-a9b3-11330977c64f/

gemini-airdrop.netlify.com
Trust trading scam site
https://urlscan.io/result/18f68b4b-aaef-47a3-aaf9-3615fc89d01a
address: 0xd88b17314696aFcbBa531F1BbadE53FcF5bC6018