### PR TITLE
muskbit.com + blockchain5th.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"muskbit.com",
+"blockchain5th.com",  
 "ltdex.market",
 "dogechain.org",
 "exodus.icu",


### PR DESCRIPTION
muskbit.com
Trust trading scam site - reported address 1AyQwZYKU36yiFPPoqnC1Cn4LLHQ1DbTDX
https://urlscan.io/result/3c27f0ec-f2a3-4ce3-a5b6-4f63dc218f3c/

blockchain5th.com
Trust trading scam site
https://urlscan.io/result/961f417e-1745-4d35-9953-0282aaf733ca/
https://urlscan.io/result/eeb91df7-adcd-44f2-a342-21b34e1c85e4/
address: 0xB3805B7A3098F9E8E4C0A4bFa212d2C8d7d072a6 (eth)
address: 0x201D2A68bfB83D4DED413A29bB3B7c5002d32772 (eth)