### PR TITLE
metmamask.com + more

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,8 @@
 [
+"metmamask.com",
+"faobit.com",
+"teslapromo.org",
+"xlmget.org",
 "paubit.com",
 "spacexgives.com",
 "ethereumfond.com",


### PR DESCRIPTION
metmamask.com
Fake MetaMask site phishing for secrets with POST /save.php
https://urlscan.io/result/e70c34e8-cb58-4f34-961d-6de75eaab87e/

faobit.com
Fake exchange phishing for deposits
https://urlscan.io/result/6d9d5864-60bd-4b1d-ae80-387d8926f66b/
address: qrwpnrpq7s670s3mlurs0z4szhqwd0nq2szp2mtnn6 (bch)
address: MGVm9Hc58piyRmhyFjCgaHMiazWAcM5swF (ltc)
address: 0xd67e205A5b7A5d82B86afBC59f67f74a878D1E68 (eth)
address: 3ACfrcziWsekdTWv9ayAGLrMU2PdMsCJxo (btc)