### PR TITLE
Remove myfusionwallet.com from blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -302,7 +302,6 @@
 "xn--blocchan-g49cv1d.com",
 "investbinance.com",
 "myfusionwallet.net",
-"myfusionwallet.com",
 "btcdouble2x.site",
 "coinanytime.com",
 "ia801505.us.archive.org",


### PR DESCRIPTION
myfusionwallet.com is the legit one and belongs to the Fusion protocol.
See https://github.com/fsn-dev/awesome-fusion#wallets
myfusionwallet.net is malicious one impersonating as myfusionwallet.com

See #[3921](https://github.com/MetaMask/eth-phishing-detect/issues/3921)