### PR TITLE
Adding bitbank.land and bitbank.guru into blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"bitbank.guru",
+"bitbank.land",
 "batairdrop.net",
 "makerdaoweb.org",
 "ether-promo-participate-now.com",


### PR DESCRIPTION
These are fake site of https://bitbank.cc/ .