### PR TITLE
Add stellar.org.sb to blocklist domains

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -12718,5 +12718,6 @@
 "xn--metherwalle-uib05k.com",
 "xn--mytherwalet-obb56i.com",
 "xn--myethrwalet-6qb77c.com",
-"xn--myetherwallt-fwb.net"
+"xn--myetherwallt-fwb.net",
+"stellar.org.sb"
 ]

--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,6 @@
 [
+"stellar.org.sb"
+"accountviewer.stellar.org.sb",
 "excodus.cf",
 "exodus.cf",
 "electrume.org",
@@ -12718,6 +12720,5 @@
 "xn--metherwalle-uib05k.com",
 "xn--mytherwalet-obb56i.com",
 "xn--myethrwalet-6qb77c.com",
-"xn--myetherwallt-fwb.net",
-"stellar.org.sb"
+"xn--myetherwallt-fwb.net"
 ]


### PR DESCRIPTION
stellar.org.sb is a phishing site conducting a staking scam to collect stellar secret keys