### PR TITLE
seal.finance

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -1,4 +1,5 @@
 [
+"seal.finance",
 "privatex.io",
 "sites.google.com",
 "mycrypto.guide",  


### PR DESCRIPTION
seal.finance
Undo incorrect blacklist (assuming autoblacklisted because hosting uniswap on uniswap.seal.finance) from https://github.com/phishfort/phishfort-lists/commit/e483f46171849b8389271f348a5cfb97059b5452
https://urlscan.io/result/3b1762b7-f5d9-4e04-bde1-eb26fd58b166/