### PR TITLE
Adding harvestfinance.app to blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -1,4 +1,5 @@
 [
+"harvestfinance.app",
 "lblhblockchain.com",
 "walletconnecl.org",
 "dropelon.io",


### PR DESCRIPTION
Tries to get user to input their private key to fake metamask window 
phising URL that is used on site:https://harvestfinance.app/metamask.html
https://urlscan.io/result/c825e7f4-0f64-441c-ae52-48d88c62d5a2/

![download](https://user-images.githubusercontent.com/77693328/105079557-e1cc0700-5a8f-11eb-8a47-2e63480b0198.png)